### PR TITLE
Implement synchronized preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # .idea
 .idea/
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ The api has 2 endpoints:
 - POST `/batch`
   Triggers a batch run.
   Arguments (in body):
-- `rresource_ids`: a list of the ids of the resources to transform.
+- `resource_ids`: a list of the ids of the resources to transform.
 
 * POST `/preview`
   Arguments (in body):
-* `rresource_id`(singular!) containing the id of the resource to transform
+* `resource_id`(singular!) containing the id of the resource to transform
 * `primary_key_values`containing a list of the primary key values of the rows to transform.
 
 _Example of request_

--- a/README.md
+++ b/README.md
@@ -8,34 +8,34 @@ This repo is a POC for Live Streams ETL.
 
 A Kafka broker is used as a bus of event.
 The different sources are connected to Kafka with Kafka Connect, where config files are pushed to Kafka Connect with the API.
-A Transform Service will consume the  events  from the sources and transform them (API calls to FHIR Pipe) and re-published 
-the events transformed  in Kafka. Finally, a Load Service will consume the transformed events and load them into the MongoDB
+A Transform Service will consume the events from the sources and transform them (API calls to FHIR Pipe) and re-published
+the events transformed in Kafka. Finally, a Load Service will consume the transformed events and load them into the MongoDB
 using an internal API.
 
 ## Getting started
 
 1. Run `docker-compose up --build`: it will create the container for the different services.  
-Note that it can take few minutes at first. The logs are quite verbose, don't be afraid ! 
+   Note that it can take few minutes at first. The logs are quite verbose, don't be afraid !
 
-2. Create the configuration for kafka-connect  (See Kafka Connect section below). 
+2. Create the configuration for kafka-connect (See Kafka Connect section below).
 
-3. Play with it: 
+3. Play with it:
 
 - MIMIC / JDBC Source Connector (postgreSQL):
 
-Run the script to create some records in the MIMIC db: `python test/create_records_db.py` (ugly script, 
+Run the script to create some records in the MIMIC db: `python test/create_records_db.py` (ugly script,
 but it works fine just to test that it works)
 You can see in the logs of the `fhir_transformer` container the message and its topic. You can check inside the MIMIC DB
- that your record has been created (check config in the script - WIP)
+that your record has been created (check config in the script - WIP)
 
 - SFTPCsvSource Connector
 
-Run the script to create some .csv file in the SFTP server: `python test/create_file_stfp.py` (ugly script, 
+Run the script to create some .csv file in the SFTP server: `python test/create_file_stfp.py` (ugly script,
 but it works fine just to test that it works).
 
-4. Play with it: in the script `fhir_transformer/src/main.py`, edit the function `process_event` to do whatever you want! 
-(make sure that the consumer has suscribed to the right topics defined in the config.json files in `fhir_transformer/src/main.py:9` 
-in the variable `TOPICS`.
+4. Play with it: in the script `fhir_transformer/src/main.py`, edit the function `process_event` to do whatever you want!
+   (make sure that the consumer has suscribed to the right topics defined in the config.json files in `fhir_transformer/src/main.py:9`
+   in the variable `TOPICS`.
 
 ## FHIR River API
 
@@ -43,38 +43,39 @@ The `fhir_river_api` container is a Flask App with an API.
 This API enables us to trigger a run of the ETL (sample or batch).
 
 To do so, it produces an event in a Kafka topic listened by the extractor with the arguments received via the endpoints
-It also adds a batch_id to be used as unique identifier of a batch of event in the following steps (E,T,L)) 
+It also adds a batch_id to be used as unique identifier of a batch of event in the following steps (E,T,L))
 
 The api has 2 endpoints:
 
-- POST `/run_batch`
-Triggers a batch run.
-Arguments (in body):
+- POST `/batch`
+  Triggers a batch run.
+  Arguments (in body):
 - `rresource_ids`: a list of the ids of the resources to transform.
 
+* POST `/preview`
+  Arguments (in body):
+* `rresource_id`(singular!) containing the id of the resource to transform
+* `primary_key_values`containing a list of the primary key values of the rows to transform.
 
-- POST `/run_sample` 
-Arguments (in body):
-- `rresource_id`(singular!) containing the id of the resource to transform
-- `primary_key_values`containing a list of the primary key values of the rows to transform.
-
-*Example of request*
+_Example of request_
 
 - Batch events:
+
 ```
-curl -X POST http://localhost:5000/run_batch -d '{"resource_ids": ["ck8oojkdt27064kp4iomh5yez"]}' -H "Content-Type:application/json"
+curl -X POST http://localhost:5000/batch -d '{"resource_ids": ["ck8oojkdt27064kp4iomh5yez"]}' -H "Content-Type:application/json"
 ```
 
 - Single event:
+
 ```
-curl -X POST http://localhost:5000/run_sample -d '{"resource_id": "<id of the resource>", "primary_key_values": ["<primary key value>"]}' -H "Content-Type:application/json"
+curl -X POST http://localhost:5000/preview -d '{"resource_id": "<id of the resource>", "primary_key_values": ["<primary key value>"]}' -H "Content-Type:application/json"
 ```
 
 Event produced:
 {
-    string batch_id;
-    string resource_id;
-    string primary_key_values (None if batch )
+string batch_id;
+string resource_id;
+string primary_key_values (None if batch )
 }
 
 ## FHIR Extractor
@@ -82,6 +83,7 @@ Event produced:
 The `fhir_extractor` includes a Kafka consumer and a Kafka producer
 
 The Extractor works as follows:
+
 - the consumer listens to the topic 'extractor_trigger', when it receives an event it triggers the following steps
 - it fetches the mapping from Pyrog via a graphql API.
 - it analyzes it to store useful information about it.
@@ -91,21 +93,20 @@ The Extractor works as follows:
 
 Note that the source database credentials are fetched in the graphql query so they need to be provided in Pyrog.
 
-
 ### Environment variables
 
 Note that you'll need to have a `.env.pyrog` file containg the following variables:
 
 - FHIR_API_URL: an url to a fhir api containing the used concept maps.
-- PYROG_API_URL: an url to pyrog's graphql API 
+- PYROG_API_URL: an url to pyrog's graphql API
 - PYROG_TOKEN: a token for pyrog's API
 
 
+
 ## FHIR Transformer
 
-
-The `fhir_transformer` container includes a consumer that reads events from Kafka. 
-In the `process_events` function, each event is processed individually (transform) and published in a Kafka Topic. 
+The `fhir_transformer` container includes a consumer that reads events from Kafka.
+In the `process_events` function, each event is processed individually (transform) and published in a Kafka Topic.
 
 ## FHIR Loader
 
@@ -121,7 +122,6 @@ mongo --port 27017 --host localhost fhirstore
 ```
 
 Or you can also use a GUI as MongoDB Compass to do so.
- 
 
 ## Topic Naming Convention
 
@@ -131,26 +131,27 @@ Or you can also use a GUI as MongoDB Compass to do so.
 - `resource` is the name of the resource, for example "patients"
 - `task_type` is either "extract" or "transform"
 
-*Example*
-- `mimic-patients-extract` and `mimic-patients-transform` 
+_Example_
+
+- `mimic-patients-extract` and `mimic-patients-transform`
 
 ## Kafka Connect
 
-This folder is intended to contain the configuration files in `json` format used to start connectors in the 
+This folder is intended to contain the configuration files in `json` format used to start connectors in the
 [kafka-connect](https://docs.confluent.io/current/connect/) cluster.
-In this POC, the configuration files and the actual kafka connect cluster are stored in the same repo, but we should 
+In this POC, the configuration files and the actual kafka connect cluster are stored in the same repo, but we should
 have 2 different repos in the future, to avoid re-deploying the cluster for each new config.
 
 The config files should be added to the ./kafka_connect_connectors folder and depending if they are for a source or a sink they will go in each respective folder.
 A new connector is launched in the cluster by using one of the following two requests:
+
 - `curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" http://localhost:8083/connectors/ -d '<config.json>'`
-OR `curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" http://localhost:8083/connectors/ -d @kafka_connect_connectors/sources/<config>.json`
-    - Only to create a new connector (Not idempotent)
+  OR `curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" http://localhost:8083/connectors/ -d @kafka_connect_connectors/sources/<config>.json` - Only to create a new connector (Not idempotent)
 
 - `curl -i -X PUT -H "Accept:application/json" -H "Content-Type:application/json" http://localhost:8083/connectors/{name}/config -d '<config_without_name.json>'`
-    - To create or update, an existing, connector (idempotent)
+  - To create or update, an existing, connector (idempotent)
 
-with `<config.json>` being the configuration in `kafka_connect_connectors/sources` (copy/paste) and `<config_without_name.json>` 
+with `<config.json>` being the configuration in `kafka_connect_connectors/sources` (copy/paste) and `<config_without_name.json>`
 being only what the value associated to the key `config`.
 
 Note: More info regarding Kafka Connect REST API [here](https://docs.confluent.io/current/connect/references/restapi.html).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,12 @@ services:
     env_file:
       - .env.pyrog
     environment:
-      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      FHIRSTORE_HOST: mongo
+      FHIRSTORE_PORT: 27017
+      FHIRSTORE_DATABASE: fhirstore
+      FHIRSTORE_USER: null
+      FHIRSTORE_PASSWORD: null
     ports:
       - 5002
 
@@ -138,11 +143,6 @@ services:
       - .env.pyrog
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      POSTGRES_USER: mimicuser
-      POSTGRES_PASSWORD: mimicuser
-      POSTGRES_DB: mimic
-      POSTGRES_HOST: mimic
-      POSTGRES_PORT: 5432
     ports:
       - 5001
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,39 +61,39 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
-#  kafka_connect:
-#    image: confluentinc/cp-kafka-connect:latest
-#    restart: always
-#    container_name: kafka_connect
-#    ports:
-#      - "8083:8083"
-#    depends_on:
-#      - kafka
-#    volumes:
-#      - ./kafka_connect_connectors/plugins/confluentinc-kafka-connect-sftp-1.0.4/:/usr/share/java/kafka-connect-sftp/
-#    environment:
-#      CONNECT_CLASS_PATH: "/usr/share/java/kafka-connect-jdbc/,/usr/share/java/kafka-connect-sftp/"
-#      CONNECT_PLUGIN_PATH: /usr/share/java/
-#      CONNECT_BOOTSTRAP_SERVERS: kafka:9092
-#      CONNECT_GROUP_ID: source-kafka-connect
-#      CONNECT_CONFIG_STORAGE_TOPIC: default.config
-#      CONNECT_STATUS_STORAGE_TOPIC: default.status
-#      CONNECT_OFFSET_STORAGE_TOPIC: default.offset
-#      CONNECT_STATUS_STORAGE_PARTITIONS: 1
-#      CONNECT_OFFSET_STORAGE_PARTITIONS: 1
-#      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: "1"
-#      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "1"
-#      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: "1"
-#      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-#      CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-#      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-#      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-#      CONNECT_REST_PORT: 8083
-#      CONNECT_REST_ADVERTISED_HOST_NAME: docker
-#      CONNECT_SCHEMAS_ENABLE: "false"
-#      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
-#      CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "false"
-#      CONNECT_ZOOKEEPER_CONNECT: zookeeper:2181
+  #  kafka_connect:
+  #    image: confluentinc/cp-kafka-connect:latest
+  #    restart: always
+  #    container_name: kafka_connect
+  #    ports:
+  #      - "8083:8083"
+  #    depends_on:
+  #      - kafka
+  #    volumes:
+  #      - ./kafka_connect_connectors/plugins/confluentinc-kafka-connect-sftp-1.0.4/:/usr/share/java/kafka-connect-sftp/
+  #    environment:
+  #      CONNECT_CLASS_PATH: "/usr/share/java/kafka-connect-jdbc/,/usr/share/java/kafka-connect-sftp/"
+  #      CONNECT_PLUGIN_PATH: /usr/share/java/
+  #      CONNECT_BOOTSTRAP_SERVERS: kafka:9092
+  #      CONNECT_GROUP_ID: source-kafka-connect
+  #      CONNECT_CONFIG_STORAGE_TOPIC: default.config
+  #      CONNECT_STATUS_STORAGE_TOPIC: default.status
+  #      CONNECT_OFFSET_STORAGE_TOPIC: default.offset
+  #      CONNECT_STATUS_STORAGE_PARTITIONS: 1
+  #      CONNECT_OFFSET_STORAGE_PARTITIONS: 1
+  #      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: "1"
+  #      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "1"
+  #      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: "1"
+  #      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+  #      CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+  #      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+  #      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+  #      CONNECT_REST_PORT: 8083
+  #      CONNECT_REST_ADVERTISED_HOST_NAME: docker
+  #      CONNECT_SCHEMAS_ENABLE: "false"
+  #      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
+  #      CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "false"
+  #      CONNECT_ZOOKEEPER_CONNECT: zookeeper:2181
 
   fhir_transformer:
     build:
@@ -107,6 +107,8 @@ services:
       - .env.pyrog
     environment:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+    ports:
+      - 5002
 
   fhir_loader:
     build:
@@ -136,6 +138,13 @@ services:
       - .env.pyrog
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      POSTGRES_USER: mimicuser
+      POSTGRES_PASSWORD: mimicuser
+      POSTGRES_DB: mimic
+      POSTGRES_HOST: mimic
+      POSTGRES_PORT: 5432
+    ports:
+      - 5001
 
   fhir_river_api:
     build:
@@ -147,8 +156,8 @@ services:
       - kafka
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-    expose:
-      - "5000"
+      EXTRACTOR_URL: http://fhir_extractor:5001
+      TRANSFORMER_URL: http://fhir_transformer:5002
     ports:
       - "5000:5000"
 

--- a/fhir_extractor/Dockerfile
+++ b/fhir_extractor/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.7-slim
 
+RUN apt-get update \
+    && apt-get -y install build-essential
+
 ARG EXTRACTOR_SQL_HOME=/app
 ENV PYTHONPATH=${EXTRACTOR_SQL_HOME}
 
@@ -9,8 +12,10 @@ COPY requirements.txt ${EXTRACTOR_SQL_HOME}/requirements.txt
 
 RUN pip install -r ${EXTRACTOR_SQL_HOME}/requirements.txt
 
-COPY /src ${EXTRACTOR_SQL_HOME}/fhir_extractor/src
+COPY src ${EXTRACTOR_SQL_HOME}/fhir_extractor/src
 
-COPY /entrypoint.sh /entrypoint.sh
+COPY uwsgi.ini ${EXTRACTOR_SQL_HOME}/fhir_extractor/uwsgi.ini
+
+COPY entrypoint.sh /entrypoint.sh
 
 CMD ["sh", "/entrypoint.sh"]

--- a/fhir_extractor/entrypoint.sh
+++ b/fhir_extractor/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Run APP
-python fhir_extractor/src/main.py
+uwsgi --ini fhir_extractor/uwsgi.ini --py-autoreload 1

--- a/fhir_extractor/requirements.txt
+++ b/fhir_extractor/requirements.txt
@@ -5,3 +5,4 @@ flask_sqlalchemy==2.3.2
 pandas==0.25.3
 psycopg2-binary==2.7.7
 requests==2.21.0
+uWSGI==2.0.18

--- a/fhir_extractor/src/consumer_class.py
+++ b/fhir_extractor/src/consumer_class.py
@@ -5,7 +5,7 @@ from confluent_kafka import KafkaException, KafkaError
 from confluent_kafka import Consumer
 from fhir_extractor.src.config.logger import create_logger
 
-logging = create_logger("fhir_extractor_consumer")
+logger = create_logger("fhir_extractor_consumer")
 
 
 class ExtractorConsumer:
@@ -78,7 +78,7 @@ class ExtractorConsumer:
         Create consumer, assign topics, consume and process events
         :return:
         """
-        logging.info(self.topics)
+        logger.info(self.topics)
         self.consumer.subscribe(self.topics)
         try:
             self.consume_event()

--- a/fhir_extractor/src/errors.py
+++ b/fhir_extractor/src/errors.py
@@ -12,3 +12,19 @@ class MissingInformationError(Exception):
     """
 
     pass
+
+
+class BadRequestError(Exception):
+    """
+    Error used when the HTTP query is not as expected.
+    """
+
+    pass
+
+
+class EmptyResult(Exception):
+    """
+    Error used when the query did not return any row.
+    """
+
+    pass

--- a/fhir_extractor/src/main.py
+++ b/fhir_extractor/src/main.py
@@ -133,6 +133,9 @@ def handle_bad_request(e):
     return str(e), 400
 
 
+# these decorators tell uWSGI (the server with which the app is run)
+# to spawn a new thread every time a worker starts. Hence the consumer
+# is started at the same time as the Flask API.
 @postfork
 @thread
 def run_consumer():

--- a/fhir_extractor/src/main.py
+++ b/fhir_extractor/src/main.py
@@ -110,7 +110,7 @@ def extract():
     body = request.get_json()
     resource_id = body.get("resource_id", None)
     primary_key_values = body.get("primary_key_values", None)
-    if primary_key_values is None or len(primary_key_values) == 0:
+    if not primary_key_values:
         raise BadRequestError("primary_key_values is required in request body")
 
     try:
@@ -141,7 +141,6 @@ def run_consumer():
     logger.info("Running Consumer")
 
     TOPIC = "extractor_trigger"
-    # [get_topic_name(source="mimic", resource="Patient", task_type="extract")]
     GROUP_ID = "arkhn_extractor"
 
     producer = ExtractorProducer(broker=os.getenv("KAFKA_BOOTSTRAP_SERVERS"))

--- a/fhir_extractor/src/producer_class.py
+++ b/fhir_extractor/src/producer_class.py
@@ -19,11 +19,9 @@ class ExtractorProducer:
         """
         self.broker = broker
         self.partition = 0
-        self.callback_function = (
-            callback_function if callback_function else self.callback_fn
-        )
+        self.callback_function = callback_function if callback_function else self.callback_fn
 
-        # Create consumer
+        # Create producer
         self.producer = Producer(self._generate_config())
 
     def _generate_config(self):
@@ -45,9 +43,7 @@ class ExtractorProducer:
             self.producer.produce(
                 topic=topic,
                 value=json.dumps(event, default=self.default_json_encoder),
-                callback=lambda err, msg, obj=event: self.callback_function(
-                    err, msg, obj
-                ),
+                callback=lambda err, msg, obj=event: self.callback_function(err, msg, obj),
             )
             self.producer.poll(1)  # Callback function
         except ValueError as error:

--- a/fhir_extractor/uwsgi.ini
+++ b/fhir_extractor/uwsgi.ini
@@ -1,0 +1,13 @@
+[uwsgi]
+
+module = fhir_extractor.src.main:app
+master = true
+
+processes = 1
+threads = 2
+
+http = 0.0.0.0:5001
+
+vacuum = true
+
+die-on-term = true

--- a/fhir_river_api/Dockerfile
+++ b/fhir_river_api/Dockerfile
@@ -9,8 +9,8 @@ COPY requirements.txt ${FHIR_RIVER_API_HOME}/requirements.txt
 
 RUN pip install -r ${FHIR_RIVER_API_HOME}/requirements.txt
 
-COPY /src ${FHIR_RIVER_API_HOME}/fhir_river_api/src
+COPY src ${FHIR_RIVER_API_HOME}/fhir_river_api/src
 
-COPY /entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 
 CMD ["sh", "/entrypoint.sh"]

--- a/fhir_river_api/requirements.txt
+++ b/fhir_river_api/requirements.txt
@@ -1,4 +1,4 @@
 confluent_kafka==1.3.0
 flask==1.0.2
-flask-restful==0.3.7
+requests==2.21.0
 uuid==1.30

--- a/fhir_river_api/src/app.py
+++ b/fhir_river_api/src/app.py
@@ -41,7 +41,7 @@ def trigger_sample_extractor():
 
         rows = extract_resp.json()["rows"]
         transform_resp = requests.post(
-            f"{TRANSFORMER_URL}/transform", json={"resource_id": resource_id, "dataframe": rows[0]},
+            f"{TRANSFORMER_URL}/transform", json={"resource_id": resource_id, "dataframe": rows},
         )
         if transform_resp.status_code != 200:
             raise Exception(

--- a/fhir_river_api/src/config/logger.py
+++ b/fhir_river_api/src/config/logger.py
@@ -12,9 +12,7 @@ def create_logger(name, level="DEBUG"):
     logger.propagate = False
     if not logger.handlers:
         handler = logging.StreamHandler()
-        handler.setFormatter(
-            logging.Formatter("%(asctime)-15s %(levelname)-8s %(message)s")
-        )
+        handler.setFormatter(logging.Formatter("%(asctime)-15s %(levelname)-8s %(message)s"))
         logger.addHandler(handler)
     logger.setLevel(getattr(logging, level))
     return logger

--- a/fhir_transformer/Dockerfile
+++ b/fhir_transformer/Dockerfile
@@ -13,8 +13,10 @@ COPY requirements.txt ${CONSUMER_HOME}/requirements.txt
 
 RUN pip install -r ${CONSUMER_HOME}/requirements.txt
 
-COPY /src ${CONSUMER_HOME}/fhir_transformer/src
+COPY src ${CONSUMER_HOME}/fhir_transformer/src
 
-COPY /entrypoint.sh /entrypoint.sh
+COPY uwsgi.ini ${CONSUMER_HOME}/fhir_transformer/uwsgi.ini
+
+COPY entrypoint.sh /entrypoint.sh
 
 CMD ["sh", "/entrypoint.sh"]

--- a/fhir_transformer/entrypoint.sh
+++ b/fhir_transformer/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-sleep 5s;
+sleep 10s;
 # Run APP
 uwsgi --ini fhir_transformer/uwsgi.ini --py-autoreload 1

--- a/fhir_transformer/entrypoint.sh
+++ b/fhir_transformer/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-sleep 10s;
-python fhir_transformer/src/main.py
+sleep 5s;
+# Run APP
+uwsgi --ini fhir_transformer/uwsgi.ini --py-autoreload 1

--- a/fhir_transformer/requirements.txt
+++ b/fhir_transformer/requirements.txt
@@ -2,3 +2,5 @@ cleaning-scripts==0.2.16
 confluent_kafka==1.3.0
 requests==2.21.0
 uWSGI==2.0.18
+fhirstore==0.4.0
+jsonschema==3.0.2

--- a/fhir_transformer/requirements.txt
+++ b/fhir_transformer/requirements.txt
@@ -1,3 +1,4 @@
 cleaning-scripts==0.2.16
 confluent_kafka==1.3.0
 requests==2.21.0
+uWSGI==2.0.18

--- a/fhir_transformer/src/fhirstore.py
+++ b/fhir_transformer/src/fhirstore.py
@@ -1,0 +1,37 @@
+import os
+from pymongo import MongoClient
+import fhirstore
+
+from fhir_transformer.src.config.logger import create_logger
+
+FHIRSTORE_HOST = os.getenv("FHIRSTORE_HOST")
+FHIRSTORE_PORT = int(os.getenv("FHIRSTORE_PORT", ""))
+FHIRSTORE_DATABASE = os.getenv("FHIRSTORE_DATABASE")
+FHIRSTORE_USER = os.getenv("FHIRSTORE_USER")
+FHIRSTORE_PASSWORD = os.getenv("FHIRSTORE_PASSWORD")
+
+_client = None
+logger = create_logger("fhirstore")
+
+
+def get_mongo_client():
+    global _client
+    if _client is None:
+        _client = MongoClient(
+            host=FHIRSTORE_HOST,
+            port=FHIRSTORE_PORT,
+            username=FHIRSTORE_USER,
+            password=FHIRSTORE_PASSWORD,
+        )
+    return _client
+
+
+_fhirstore = None
+
+
+def get_fhirstore():
+    global _fhirstore
+    if _fhirstore is None:
+        _fhirstore = fhirstore.FHIRStore(get_mongo_client(), None, FHIRSTORE_DATABASE)
+        _fhirstore.resume()
+    return _fhirstore

--- a/fhir_transformer/src/fhirstore.py
+++ b/fhir_transformer/src/fhirstore.py
@@ -34,4 +34,6 @@ def get_fhirstore():
     if _fhirstore is None:
         _fhirstore = fhirstore.FHIRStore(get_mongo_client(), None, FHIRSTORE_DATABASE)
         _fhirstore.resume()
+        if len(_fhirstore.resources) == 0:
+            _fhirstore.bootstrap(depth=3)
     return _fhirstore

--- a/fhir_transformer/src/main.py
+++ b/fhir_transformer/src/main.py
@@ -97,6 +97,9 @@ def handle_bad_request(e):
     return str(e), 400
 
 
+# these decorators tell uWSGI (the server with which the app is run)
+# to spawn a new thread every time a worker starts. Hence the consumer
+# is started at the same time as the Flask API.
 @postfork
 @thread
 def run_consumer():

--- a/fhir_transformer/uwsgi.ini
+++ b/fhir_transformer/uwsgi.ini
@@ -1,0 +1,13 @@
+[uwsgi]
+
+module = fhir_transformer.src.main:app
+master = true
+
+processes = 1
+threads = 2
+
+http = 0.0.0.0:5002
+
+vacuum = true
+
+die-on-term = true


### PR DESCRIPTION
I added a Flask API on fhir_extractor (POST /extract) and fhir_transformer (POST /transform) in order to implement a sync version of the "fhir preview".

You can now send a:
```
curl -X POST http://localhost:5000/preview -d '{"resource_id": "<id of the resource>", "primary_key_values": ["<primary key value>"]}' -H "Content-Type:application/json"
```

and retrieve the transformed fhir object

I used the @postfork and @thread decorators of uwsgi (we now run the transformer and the extractor with uwsgi, it's like gunicorn) in order to spawn a consumer automatically when the api starts.