### PR TITLE
Add cleaning-scripts versions

### DIFF
--- a/extractor/requirements.txt
+++ b/extractor/requirements.txt
@@ -1,4 +1,4 @@
-cleaning-scripts
+cleaning-scripts==0.2.21
 confluent_kafka==1.3.0
 cx_Oracle==7.1.2
 flask==1.0.2

--- a/loader/requirements.txt
+++ b/loader/requirements.txt
@@ -1,4 +1,4 @@
-cleaning-scripts
+cleaning-scripts==0.2.21
 confluent_kafka==1.3.0
 fhirstore==0.3.9
 jsonschema==3.0.2

--- a/transformer/requirements.txt
+++ b/transformer/requirements.txt
@@ -1,4 +1,4 @@
-cleaning-scripts
+cleaning-scripts==0.2.21
 confluent_kafka==1.3.0
 requests==2.21.0
 uWSGI==2.0.18


### PR DESCRIPTION
Without them, docker compose will use the cached version instead of using the most recent one
Maybe there could be another option by forcing to rebuild the image (I didn't find any except for removing totally the image and repulling it, not sure we want to do that) but at least we have more control if something wrong happens.
