### PR TITLE
river-api's preview accepts []string and []int as primary_key_values

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,12 +111,12 @@ jobs:
           docker exec fhir-api python3 scripts/upload_bundles.py fhir_bundles/resources.json fhir_bundles/conceptMaps.json
           docker restart fhir-api
           docker-compose -f test/docker-compose.yml up -d postgres redis pyrog-server
-          sleep 15
+          sleep 30
           docker exec --env SUPERUSER_PASSWORD="password" pyrog-server yarn seed:superuser
           docker exec pyrog-server yarn seed:mapping /app/mapping.json
           docker exec pyrog-server yarn seed:credentials /app/credentials.json
           docker-compose -f test/docker-compose.yml up -d api extractor transformer loader
-          sleep 5
+          sleep 15
           python -m pytest -svv test/test_batch.py
 
   publish:

--- a/apigo/api/preview.go
+++ b/apigo/api/preview.go
@@ -32,8 +32,8 @@ func init() {
 // PreviewRequest is the body of the POST /preview request.
 type PreviewRequest struct {
 	// PrimaryKeyValues can be a list of strings (eg ["E65"]) or a list of integers ([59])
-	PrimaryKeyValues []json.RawMessage `json:"primary_key_values"`
-	ResourceID       string            `json:"resource_id"`
+	PrimaryKeyValues []interface{} `json:"primary_key_values"`
+	ResourceID       string        `json:"resource_id"`
 }
 
 // transform sends an HTTP request to the transformer service

--- a/apigo/api/preview.go
+++ b/apigo/api/preview.go
@@ -31,8 +31,9 @@ func init() {
 
 // PreviewRequest is the body of the POST /preview request.
 type PreviewRequest struct {
-	ResourceID       string            `json:"resource_id"`
+	// PrimaryKeyValues can be a list of strings (eg ["E65"]) or a list of integers ([59])
 	PrimaryKeyValues []json.RawMessage `json:"primary_key_values"`
+	ResourceID       string            `json:"resource_id"`
 }
 
 // transform sends an HTTP request to the transformer service

--- a/apigo/api/preview.go
+++ b/apigo/api/preview.go
@@ -31,8 +31,8 @@ func init() {
 
 // PreviewRequest is the body of the POST /preview request.
 type PreviewRequest struct {
-	ResourceID       string        `json:"resource_id"`
-	PrimaryKeyValues []json.Number `json:"primary_key_values"`
+	ResourceID       string            `json:"resource_id"`
+	PrimaryKeyValues []json.RawMessage `json:"primary_key_values"`
 }
 
 // transform sends an HTTP request to the transformer service

--- a/apigo/api/preview.go
+++ b/apigo/api/preview.go
@@ -31,8 +31,8 @@ func init() {
 
 // PreviewRequest is the body of the POST /preview request.
 type PreviewRequest struct {
-	ResourceID       string   `json:"resource_id"`
-	PrimaryKeyValues []string `json:"primary_key_values"`
+	ResourceID       string        `json:"resource_id"`
+	PrimaryKeyValues []json.Number `json:"primary_key_values"`
 }
 
 // transform sends an HTTP request to the transformer service

--- a/apigo/api/preview_test.go
+++ b/apigo/api/preview_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreview(t *testing.T) {
+
+	mockExtractor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"rows": []}`)
+	}))
+	defer mockExtractor.Close()
+	mockTransformer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	}))
+	defer mockTransformer.Close()
+
+	transformerURL = mockTransformer.URL
+	extractorURL = mockExtractor.URL
+
+	t.Run("accepts primary keys as strings", func(t *testing.T) {
+		// use a list of strings in primary_key_values
+		b := bytes.NewReader([]byte(`{"resource_id": "1", "primary_key_values": ["1"]}`))
+		req, err := http.NewRequest("POST", "/preview", b)
+		assert.NoError(t, err)
+
+		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+		rr := httptest.NewRecorder()
+		router := httprouter.New()
+		router.POST("/preview", Preview)
+
+		// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+		// directly and pass in our Request and ResponseRecorder.
+		router.ServeHTTP(rr, req)
+
+		// Check the status code is what we expect.
+		assert.Equal(t, http.StatusOK, rr.Code, "bad response status")
+
+		// Check the response body is what we expect.
+		assert.Equal(t, `{}`, rr.Body.String(), "bad response body")
+	})
+
+	t.Run("accepts primary keys as integers", func(t *testing.T) {
+		// use a list of integers in primary_key_values
+		b := bytes.NewReader([]byte(`{"resource_id": "1", "primary_key_values": [1]}`))
+		req, err := http.NewRequest("POST", "/preview", b)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		router := httprouter.New()
+		router.POST("/preview", Preview)
+
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code, "bad response status")
+
+		assert.Equal(t, `{}`, rr.Body.String(), "bad response body")
+	})
+}

--- a/apigo/api/preview_test.go
+++ b/apigo/api/preview_test.go
@@ -63,4 +63,21 @@ func TestPreview(t *testing.T) {
 
 		assert.Equal(t, `{}`, rr.Body.String(), "bad response body")
 	})
+
+	t.Run("accepts arbitrary primary keys", func(t *testing.T) {
+		// use a list of integers in primary_key_values
+		b := bytes.NewReader([]byte(`{"resource_id": "1", "primary_key_values": ["E98"]}`))
+		req, err := http.NewRequest("POST", "/preview", b)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		router := httprouter.New()
+		router.POST("/preview", Preview)
+
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code, "bad response status")
+
+		assert.Equal(t, `{}`, rr.Body.String(), "bad response body")
+	})
 }

--- a/apigo/go.mod
+++ b/apigo/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/segmentio/kafka-go v0.3.6
 	github.com/sirupsen/logrus v1.6.0
+	github.com/stretchr/testify v1.2.2
 )

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -47,7 +47,7 @@ def test_batch_single_row():
     def wait_batch(msg):
         msg_value = json.loads(msg.value())
         print(f"Go batch of size {msg_value['size']}, consuming events...")
-        consumer.run_consumer(event_count=msg_value["size"], poll_timeout=30)
+        consumer.run_consumer(event_count=msg_value["size"], poll_timeout=45)
 
     batch_size_consumer = EventConsumer(
         broker=os.getenv("KAFKA_BOOTSTRAP_SERVERS_EXTERNAL"),
@@ -69,7 +69,7 @@ def test_batch_single_row():
         assert response.status_code == 200, f"api POST /batch returned an error: {response.text}"
 
         print("Waiting for a batch_size event...")
-        batch_size_consumer.run_consumer(event_count=1, poll_timeout=30)
+        batch_size_consumer.run_consumer(event_count=1, poll_timeout=45)
 
 
 # check in elastic that references have been set


### PR DESCRIPTION
Fix #75 