### PR TITLE
Serialize decimal to int string if needed

### DIFF
--- a/extractor/src/json_encoder.py
+++ b/extractor/src/json_encoder.py
@@ -12,10 +12,6 @@ class MyJSONEncoder(flask.json.JSONEncoder):
     """
     def default(self, obj):
         if isinstance(obj, decimal.Decimal):
-            # Convert decimal instances to strings
-            # If the decimal reprensents an integer, we want to avoid a trailing ".0"
-            nearest_int = obj.to_integral_exact()
-            if nearest_int == obj:
-                return str(nearest_int)
-            return str(obj)
+            # Convert decimal instances to strings without trailing 0
+            return str(obj.normalize())
         return super(MyJSONEncoder, self).default(obj)

--- a/extractor/src/json_encoder.py
+++ b/extractor/src/json_encoder.py
@@ -13,5 +13,9 @@ class MyJSONEncoder(flask.json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, decimal.Decimal):
             # Convert decimal instances to strings
+            # If the decimal reprensents an integer, we want to avoid a trailing ".0"
+            nearest_int = obj.to_integral_exact()
+            if nearest_int == obj:
+                return str(nearest_int)
             return str(obj)
         return super(MyJSONEncoder, self).default(obj)

--- a/extractor/test/test_json_encoder.py
+++ b/extractor/test/test_json_encoder.py
@@ -1,0 +1,16 @@
+from decimal import Decimal
+
+from extractor.src.json_encoder import MyJSONEncoder
+
+
+def test_encode_decimal():
+    json_encoder = MyJSONEncoder()
+
+    encoded = json_encoder.default(Decimal("5.0"))
+    assert encoded == "5"
+
+    encoded = json_encoder.default(Decimal("5"))
+    assert encoded == "5"
+
+    encoded = json_encoder.default(Decimal("5.1030000"))
+    assert encoded == "5.103"


### PR DESCRIPTION
## Fixes
Fixes ##126 by @elsiehoffet-94 

## Description
If an extracted number actually represents an int, then we force the string serialization to represent an integer.

## Technical details
Maybe this would need some further thinking, can we find a better solution?