### PR TITLE
Fix how identifiers are used in references

### DIFF
--- a/loader/src/reference_binder.py
+++ b/loader/src/reference_binder.py
@@ -25,12 +25,13 @@ def partial_identifier(identifier):
         identifier_type_code,
         identifier_type_system,
     ) = ReferenceBinder.extract_key_tuple(identifier)
-    if value:
+    if system:
         return {"identifier.value": value, "identifier.system": system}
     else:
         return {
-            "identifier.type.coding.0.code": identifier_type_code,
-            "identifier.type.coding.0.system": identifier_type_system,
+            "identifier.value": value,
+            "identifier.type.coding.code": identifier_type_code,
+            "identifier.type.coding.system": identifier_type_system,
         }
 
 
@@ -144,10 +145,7 @@ class ReferenceBinder:
                 # otherwise, cache in Redis the reference to resolve it later
                 target_ref = (reference_type, identifier_tuple)
                 source_ref = (fhir_object["resourceType"], reference_path, isArray)
-                self.cache.sadd(
-                    json.dumps(target_ref),
-                    json.dumps((source_ref, fhir_object["id"]))
-                )
+                self.cache.sadd(json.dumps(target_ref), json.dumps((source_ref, fhir_object["id"])))
             return ref
 
         # If we have a list of references, we want to bind all of them.
@@ -189,15 +187,9 @@ class ReferenceBinder:
         identifier_type_system = identifier_type_coding.get("system")
         identifier_type_code = identifier_type_coding.get("code")
 
-        if not (bool(value and system) ^ bool(identifier_type_system and identifier_type_code)):
-            raise Exception(
-                f"invalid identifier: {identifier} (identifier.value and identifier.system) "
-                "or (identifier.type.coding.code and identifier.type.coding.system) are required "
-                "and mutually exclusive"
-            )
-
         return value, system, identifier_type_code, identifier_type_system
 
+    @Timer("time_load_cached_references", "time spent loading references from redis")
     def load_cached_references(self, target_ref: str) -> DefaultDict[tuple, list]:
         """Requests cached references from Redis
 

--- a/loader/test/conftest.py
+++ b/loader/test/conftest.py
@@ -50,6 +50,7 @@ def patient_code_identifier():
                 "assigner": {
                     "type": "Organization",
                     "identifier": {
+                        "value": "654",
                         "type": {
                             "coding": [
                                 {"code": "code_456", "system": "fhir_code_system_organization"}
@@ -63,6 +64,7 @@ def patient_code_identifier():
             {
                 "type": "Practitioner",
                 "identifier": {
+                    "value": "222",
                     "type": {
                         "coding": [{"code": "code_123", "system": "fhir_code_system_practitioner"}]
                     },
@@ -72,6 +74,7 @@ def patient_code_identifier():
         "managingOrganization": {
             "type": "Organization",
             "identifier": {
+                "value": "333",
                 "type": {
                     "coding": [{"code": "code_789", "system": "fhir_code_system_organization"}]
                 },
@@ -87,7 +90,12 @@ def test_practitioner():
         "resourceType": "Practitioner",
         "identifier": [
             {"system": "http://terminology.arkhn.org/mimic_id/practitioner_id", "value": "123"},
-            {"type": {"coding": [{"code": "code_123", "system": "fhir_code_system_practitioner"}]}},
+            {
+                "value": "222",
+                "type": {
+                    "coding": [{"code": "code_123", "system": "fhir_code_system_practitioner"}]
+                },
+            },
         ],
     }
 
@@ -100,7 +108,17 @@ def test_organization():
         "identifier": [
             {"system": "http://terminology.arkhn.org/mimic_id/organization_id", "value": "456"},
             {"system": "http://terminology.arkhn.org/mimic_id/organization_id", "value": "789"},
-            {"type": {"coding": [{"code": "code_456", "system": "fhir_code_system_organization"}]}},
-            {"type": {"coding": [{"code": "code_789", "system": "fhir_code_system_organization"}]}},
+            {
+                "value": "654",
+                "type": {
+                    "coding": [{"code": "code_456", "system": "fhir_code_system_organization"}]
+                },
+            },
+            {
+                "value": "333",
+                "type": {
+                    "coding": [{"code": "code_789", "system": "fhir_code_system_organization"}]
+                },
+            },
         ],
     }


### PR DESCRIPTION
## Fixes
We misunderstood how identifiers are built: they always have a value and the "referential" can be indicated whether with system or with both type.coding.system and type.coding.code
If they have both, the system is used but we should allow it