### PR TITLE
Return raw value on Attribute.cast_type error

### DIFF
--- a/analyzer/src/analyze/attribute.py
+++ b/analyzer/src/analyze/attribute.py
@@ -25,6 +25,7 @@ class Attribute:
     ):
         self.path = path
         self.input_groups = input_groups or []
+        self.type = numerical_types_map.get(definition_id, str)
         self.normalizer = numerical_types_map.get(definition_id, normalize_to_str)
 
     def __eq__(self, other):
@@ -48,7 +49,9 @@ class Attribute:
         try:
             return self.normalizer(value)
         except Exception as e:
-            logger.error(
+            logger.warning(
                 f"Could not cast value {value} to type {self.type} "
                 f"on attribute at path = {self.path}): {e}"
             )
+
+        return value

--- a/analyzer/test/analyze/test_attribute.py
+++ b/analyzer/test/analyze/test_attribute.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from analyzer.src.analyze.attribute import Attribute
 from analyzer.src.analyze.input_group import InputGroup
 
@@ -11,8 +13,19 @@ def test_cast_type():
     assert group.static_inputs == ["string"]
 
     # To number
-    attr_int = Attribute("name", definition_id="integer")
+    attr_int = Attribute("age", definition_id="integer")
     group = InputGroup(id_="id", attribute=attr_int)
     group.add_static_input("123")
 
     assert group.static_inputs == [123]
+
+
+@mock.patch("analyzer.src.analyze.attribute.logger")
+def test_cast_type_fail(mock_logger):
+    # To string
+    attr_str = Attribute("age", definition_id="integer")
+    group = InputGroup(id_="id", attribute=attr_str)
+    group.add_static_input("error")
+
+    mock_logger.warning.assert_called_once()
+    assert group.static_inputs == ["error"]


### PR DESCRIPTION
- Return original if fails to cast type
- Add a type attribute for error message
- Change logging level to warning

Fixes #155