### PR TITLE
Reformat failed validation error message

### DIFF
--- a/loader/src/load/loader.py
+++ b/loader/src/load/loader.py
@@ -37,7 +37,8 @@ class Loader:
             ).inc()
             # Log
             logger.error(
-                f"Validation failed for resource {fhir_instance}: "
-                f"{[issue.diagnostics for issue in resource.issue]}",
+                f"Validation failed\n"
+                f"Diagnostics: {[issue.diagnostics for issue in resource.issue]}\n"
+                f"Document: {fhir_instance}",
                 extra={"resource_id": resource_id},
             )


### PR DESCRIPTION
Do you think the document (and maybe the diagnostics?) should even be given as log fields?