### PR TITLE
Avoid scientific notation when casting to string

### DIFF
--- a/analyzer/src/analyze/attribute.py
+++ b/analyzer/src/analyze/attribute.py
@@ -16,6 +16,7 @@ numerical_types_map = {
 def normalize_to_str(value):
     if isinstance(value, float):
         value = Decimal(value).normalize()
+        return format(value, "f")
     return str(value)
 
 

--- a/analyzer/test/analyze/test_attribute.py
+++ b/analyzer/test/analyze/test_attribute.py
@@ -4,15 +4,23 @@ from analyzer.src.analyze.attribute import Attribute
 from analyzer.src.analyze.input_group import InputGroup
 
 
-def test_cast_type():
-    # To string
+def test_cast_type_string():
     attr_str = Attribute("name", definition_id="code")
     group = InputGroup(id_="id", attribute=attr_str)
     group.add_static_input("string")
 
     assert group.static_inputs == ["string"]
 
-    # To number
+
+def test_cast_type_no_scientific_notation():
+    attr_int = Attribute("code", definition_id="code")
+    group = InputGroup(id_="id", attribute=attr_int)
+    group.add_static_input(100.)
+
+    assert group.static_inputs == ["100"]
+
+
+def test_cast_type_number():
     attr_int = Attribute("age", definition_id="integer")
     group = InputGroup(id_="id", attribute=attr_int)
     group.add_static_input("123")
@@ -22,7 +30,6 @@ def test_cast_type():
 
 @mock.patch("analyzer.src.analyze.attribute.logger")
 def test_cast_type_fail(mock_logger):
-    # To string
     attr_str = Attribute("age", definition_id="integer")
     group = InputGroup(id_="id", attribute=attr_str)
     group.add_static_input("error")


### PR DESCRIPTION
## Description
Sometimes, Decimal were cast to strings with scientific notation. We want to avoid that (at least most the time?)

## Tests
Unit tests
