### PR TITLE
[clean] Remove unneeded function

### DIFF
--- a/transformer/src/transform/fhir.py
+++ b/transformer/src/transform/fhir.py
@@ -163,27 +163,6 @@ def insert_in_fhir_object(fhir_object, path, value):
         cur_location[path[-1]] = val
 
 
-def clean_fhir_object(fhir_obj):
-    """ Remove duplicate list elements from fhir object
-    """
-    if isinstance(fhir_obj, dict):
-        for key in fhir_obj:
-            fhir_obj[key] = clean_fhir_object(fhir_obj[key])
-        return fhir_obj
-
-    elif isinstance(fhir_obj, list):
-        to_rm = []
-        for i in range(len(fhir_obj)):
-            for j in range(i + 1, len(fhir_obj)):
-                if fhir_obj[i] == fhir_obj[j]:
-                    to_rm.append(i)
-                    break
-        return [el for ind, el in enumerate(fhir_obj) if ind not in to_rm]
-
-    else:
-        return fhir_obj
-
-
 def get_position_first_index(path):
     # Find first step which has an index
     for i, step in enumerate(path):

--- a/transformer/src/transform/transformer.py
+++ b/transformer/src/transform/transformer.py
@@ -9,7 +9,6 @@ from transformer.src.transform.dataframe import squash_rows
 from transformer.src.transform.dataframe import merge_by_attributes
 from transformer.src.transform.fhir import build_fhir_object
 from transformer.src.transform.fhir import build_metadata
-from transformer.src.transform.fhir import clean_fhir_object
 
 
 class Transformer:
@@ -64,8 +63,5 @@ class Transformer:
         fhir_object["id"] = str(uuid4())
         fhir_object["resourceType"] = analysis.definition["type"]
         fhir_object["meta"] = build_metadata(analysis)
-
-        # Remove duplicates in fhir object
-        fhir_object = clean_fhir_object(fhir_object)
 
         return fhir_object

--- a/transformer/test/transform/test_fhir.py
+++ b/transformer/test/transform/test_fhir.py
@@ -124,21 +124,6 @@ def test_array_of_literals():
     assert fhir_object == {"name": [{"given": ["Bob", "Dylan"]}], "other_attr": "Ross"}
 
 
-def test_clean_fhir_object():
-    dirty = {
-        "a": {"b": [{"c": 123}, {"c": 123}, {"c": 123}, {"c": 222}, {"c": 222}]},
-        "d": [{"e": {"f": 456}}, {"e": {"f": 456}}, {"e": 456}],
-    }
-    clean = transform.clean_fhir_object(dirty)
-
-    expected = {
-        "a": {"b": [{"c": 123}, {"c": 222}]},
-        "d": [{"e": {"f": 456}}, {"e": 456}],
-    }
-
-    assert clean == expected
-
-
 def test_get_position_first_index():
     path = ["root", "identifier[0]", "value"]
     index = transform.get_position_first_index(path)


### PR DESCRIPTION
## Description
Remove `clean_fhir_object` which was introduced as an ugly fix for shaky `group_by`s.

## Tests
Tested on dev, mapping with joins don't have any duplicated array elements.
