### PR TITLE
fix: replace panic by fatal to exit

### DIFF
--- a/api/topics/monitor/listen_and_destroy.go
+++ b/api/topics/monitor/listen_and_destroy.go
@@ -73,7 +73,7 @@ func (ctl BatchController) ListenAndDestroy() {
 		"topic.metadata.refresh.interval.ms": 5000,
 		"auto.offset.reset":                  "earliest"})
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	defer func() {
 		log.Println("Closing consumer")


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
* If the api can't connect to Kafka at launch, it should crash and restart
