### PR TITLE
fix: kafka perfomance and set redis counter even if an exception is raised

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/confluentinc/confluent-kafka-go v1.4.2
+	github.com/confluentinc/confluent-kafka-go v1.5.2
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/gomodule/redigo v1.8.2 // indirect
 	github.com/google/go-cmp v0.5.2 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -8,6 +8,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/confluentinc/confluent-kafka-go v1.4.2 h1:13EK9RTujF7lVkvHQ5Hbu6bM+Yfrq8L0MkJNnjHSd4Q=
 github.com/confluentinc/confluent-kafka-go v1.4.2/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
+github.com/confluentinc/confluent-kafka-go v1.5.2 h1:l+qt+a0Okmq0Bdr1P55IX4fiwFJyg0lZQmfHkAFkv7E=
+github.com/confluentinc/confluent-kafka-go v1.5.2/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/api/mapping/fetch.go
+++ b/api/mapping/fetch.go
@@ -175,7 +175,7 @@ func Fetch(resourceID string, authorizationHeader string) (*resource, error) {
 				StatusCode: http.StatusForbidden,
 			}
 		default:
-			return nil, fmt.Errorf("error while requesting mapping from Pyrog")
+			return nil, fmt.Errorf(gqlResp.Errors[0].Message)
 		}
 	}
 	resourceMapping := gqlResp.Data.Resource

--- a/api/mapping/fetch.go
+++ b/api/mapping/fetch.go
@@ -164,7 +164,7 @@ func Fetch(resourceID string, authorizationHeader string) (*resource, error) {
 		return nil, err
 	}
 
-	// grqphql errors are retured as httpo.StatusOK but contains an "error"
+	// grqphql errors are retured as http.StatusOK but contains an "error"
 	if gqlResp.Errors != nil {
 		switch gqlResp.Errors[0].StatusCode {
 		case http.StatusUnauthorized:

--- a/api/mapping/mapping_test.go
+++ b/api/mapping/mapping_test.go
@@ -40,7 +40,7 @@ func TestFetch(t *testing.T) {
 	})
 
 	t.Run("query pyrog with invalid token", func(t *testing.T) {
-		_, err := Fetch("resourceID", "Bearer invalidToken")
+		_, err := Fetch("resourceID", "Bearer unauthorizedToken")
 		assert.Error(t, err)
 
 		got, isInvalidTokenError := err.(*errors.InvalidTokenError)
@@ -48,6 +48,13 @@ func TestFetch(t *testing.T) {
 			t.Fatalf("expected an isInvalidTokenError, got %v", err)
 		}
 		assert.Equal(t, http.StatusUnauthorized, got.StatusCode, "status code is incorrect")
+	})
+
+	t.Run("query pyrog bad request", func(t *testing.T) {
+		_, err := Fetch("resourceID", "bad request")
+		assert.Error(t, err)
+
+		assert.EqualError(t, err, "error while requesting mapping from Pyrog")
 	})
 }
 

--- a/api/mocks/pyrog_server.go
+++ b/api/mocks/pyrog_server.go
@@ -7,15 +7,17 @@ import (
 )
 
 func PyrogServer() *httptest.Server {
-	pyrogResponse := fmt.Sprintf(`{"data": {"resource": %s}}`, patientMapping)
 	mockPyrogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authorizationHeader := r.Header.Get("Authorization")
 		if authorizationHeader == "Bearer validToken" {
+			pyrogResponse := fmt.Sprintf(`{"data": {"resource": %s}}`, patientMapping)
 			_, _ = fmt.Fprint(w, pyrogResponse)
 		} else if authorizationHeader == "Bearer forbiddenToken" {
-			http.Error(w, "invalid token", http.StatusForbidden)
+			fmt.Fprint(w, `{"errors": [{"statusCode": 403, "message": "forbidden"}]}`)
+		} else if authorizationHeader == "Bearer unauthorizedToken" {
+			fmt.Fprint(w, `{"errors": [{"statusCode": 401, "message": "unauthorized"}]}`)
 		} else {
-			http.Error(w, "invalid token", http.StatusUnauthorized)
+			http.Error(w, "invalid token", http.StatusBadRequest)
 		}
 	}))
 	return mockPyrogServer

--- a/api/routes/preview/preview_test.go
+++ b/api/routes/preview/preview_test.go
@@ -124,10 +124,11 @@ func TestPreview(t *testing.T) {
 		assert.Equal(t, `{}`, rr.Body.String(), "bad response body")
 	})
 
-	t.Run("returns an error if invalid auth token", func(t *testing.T) {
+	t.Run("returns an error if unauthorized auth token", func(t *testing.T) {
 		// use a list of strings in primary_key_values
 		b := bytes.NewReader([]byte(`{"resource_id": "1", "preview_id": "u-u-i-d", "primary_key_values": ["1"]}`))
 		req, err := http.NewRequest("POST", "/preview", b)
+		req.Header.Add("Authorization", "Bearer unauthorizedToken")
 		assert.NoError(t, err)
 
 		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.

--- a/extractor/requirements/requirements-base.txt
+++ b/extractor/requirements/requirements-base.txt
@@ -1,6 +1,6 @@
 arkhn-monitoring==0.0.4
 cleaning-scripts==0.2.27
-confluent_kafka==1.3.0
+confluent_kafka==1.5.0
 flask==1.0.2
 flask-restful==0.3.7
 flask_sqlalchemy==2.3.2

--- a/extractor/requirements/requirements-base.txt
+++ b/extractor/requirements/requirements-base.txt
@@ -1,6 +1,6 @@
 arkhn-monitoring==0.0.4
 cleaning-scripts==0.2.27
-confluent_kafka==1.5.0
+confluent_kafka==1.3.0
 flask==1.0.2
 flask-restful==0.3.7
 flask_sqlalchemy==2.3.2

--- a/extractor/src/main.py
+++ b/extractor/src/main.py
@@ -204,14 +204,18 @@ def process_event_with_context(producer):
                 )
             else:
                 logger.error(format_traceback())
-        # Initialize a batch counter in Redis. For each resource_id, it records
-        # the number of produced records
-        redis_counter_client.hset(f"batch:{batch_id}:counter", f"resource:{resource_id}:extracted",
-                                  count)
-        logger.info(
-            f"Batch {batch_id} size is {count} for resource type {analysis.definition_id}",
-            extra={"resource_id": resource_id},
-        )
+        finally:
+            # Initialize a batch counter in Redis. For each resource_id, it records
+            # the number of produced records
+            redis_counter_client.hset(
+                f"batch:{batch_id}:counter",
+                f"resource:{resource_id}:extracted",
+                count
+            )
+            logger.info(
+                f"Batch {batch_id} size is {count} for resource type {analysis.definition_id}",
+                extra={"resource_id": resource_id},
+            )
 
     def process_event(msg):
         msg_value = json.loads(msg.value())

--- a/extractor/src/producer_class.py
+++ b/extractor/src/producer_class.py
@@ -28,7 +28,7 @@ class ExtractorProducer:
         Generate configuration dictionary for consumer
         :return:
         """
-        config = {"bootstrap.servers": self.broker}
+        config = {"bootstrap.servers": self.broker, "session.timeout.ms": 6000}
         return config
 
     def produce_event(self, topic, event):

--- a/extractor/src/producer_class.py
+++ b/extractor/src/producer_class.py
@@ -28,7 +28,7 @@ class ExtractorProducer:
         Generate configuration dictionary for consumer
         :return:
         """
-        config = {"bootstrap.servers": self.broker, "session.timeout.ms": 6000}
+        config = {"bootstrap.servers": self.broker, "linger.ms": 0.5}
         return config
 
     def produce_event(self, topic, event):

--- a/extractor/src/producer_class.py
+++ b/extractor/src/producer_class.py
@@ -28,6 +28,9 @@ class ExtractorProducer:
         Generate configuration dictionary for consumer
         :return:
         """
+        # confluent-kafka-python v1.5.0 release note:
+        # The default producer batch accumulation time, linger.ms, has been changed
+        # from 0.5ms to 5ms but we require lower produce latency
         config = {"bootstrap.servers": self.broker, "linger.ms": 0.5}
         return config
 

--- a/loader/src/producer_class.py
+++ b/loader/src/producer_class.py
@@ -29,7 +29,7 @@ class LoaderProducer:
         Generate configuration dictionary for consumer
         :return:
         """
-        config = {"bootstrap.servers": self.broker}
+        config = {"bootstrap.servers": self.broker, "session.timeout.ms": 6000}
         return config
 
     def produce_event(self, topic, record):

--- a/loader/src/producer_class.py
+++ b/loader/src/producer_class.py
@@ -29,7 +29,7 @@ class LoaderProducer:
         Generate configuration dictionary for consumer
         :return:
         """
-        config = {"bootstrap.servers": self.broker, "session.timeout.ms": 6000}
+        config = {"bootstrap.servers": self.broker, "linger.ms": 0.5}
         return config
 
     def produce_event(self, topic, record):

--- a/loader/src/producer_class.py
+++ b/loader/src/producer_class.py
@@ -29,6 +29,9 @@ class LoaderProducer:
         Generate configuration dictionary for consumer
         :return:
         """
+        # confluent-kafka-python v1.5.0 release note:
+        # The default producer batch accumulation time, linger.ms, has been changed
+        # from 0.5ms to 5ms but we require lower produce latency
         config = {"bootstrap.servers": self.broker, "linger.ms": 0.5}
         return config
 

--- a/transformer/src/producer_class.py
+++ b/transformer/src/producer_class.py
@@ -28,7 +28,10 @@ class TransformerProducer:
         """
         Generate configuration dictionary for consumer
         """
-        config = {"bootstrap.servers": self.broker}
+        # confluent-kafka-python v1.5.0 release note:
+        # The default producer batch accumulation time, linger.ms, has been changed
+        # from 0.5ms to 5ms but we require lower produce latency
+        config = {"bootstrap.servers": self.broker, "linger.ms": 0.5}
         return config
 
     def produce_event(self, topic, record):

--- a/transformer/src/producer_class.py
+++ b/transformer/src/producer_class.py
@@ -28,7 +28,7 @@ class TransformerProducer:
         """
         Generate configuration dictionary for consumer
         """
-        config = {"bootstrap.servers": self.broker, "session.timeout.ms": 6000}
+        config = {"bootstrap.servers": self.broker, "linger.ms": 0.5}
         return config
 
     def produce_event(self, topic, record):

--- a/transformer/src/producer_class.py
+++ b/transformer/src/producer_class.py
@@ -28,7 +28,7 @@ class TransformerProducer:
         """
         Generate configuration dictionary for consumer
         """
-        config = {"bootstrap.servers": self.broker}
+        config = {"bootstrap.servers": self.broker, "session.timeout.ms": 6000}
         return config
 
     def produce_event(self, topic, record):

--- a/transformer/src/producer_class.py
+++ b/transformer/src/producer_class.py
@@ -28,7 +28,7 @@ class TransformerProducer:
         """
         Generate configuration dictionary for consumer
         """
-        config = {"bootstrap.servers": self.broker, "linger.ms": 0.5}
+        config = {"bootstrap.servers": self.broker}
         return config
 
     def produce_event(self, topic, record):


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
* If a database error occurs, the extractor should set the number of previously produced messages in the Redis counter in order to terminate the batch.
* Fix Kafka performance issues after bumping to v1.5.0 of Kafka confluent python (wrapper of librdkafka). https://github.com/edenhill/librdkafka/releases/tag/v1.5.0
```
The default producer batch accumulation time, linger.ms, has been changed
from 0.5ms to 5ms to improve batch sizes and throughput while reducing
the per-message protocol overhead.
Applications that require lower produce latency than 5ms will need to
manually set linger.ms to a lower value.
```
