### PR TITLE
[docker] automatically accept mssql upgrade terms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 WORKDIR /srv
 
 RUN apt-get update \
-    && apt-get upgrade -y \
+    && ACCEPT_EULA=Y apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
     binutils \
     build-essential \
@@ -49,7 +49,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 WORKDIR /srv
 
 RUN apt-get update \
-    && apt-get upgrade -y \
+    && ACCEPT_EULA=Y apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
     curl libpq-dev \
     && apt-get autoremove --purge -y \


### PR DESCRIPTION
When running apt-get upgrade, we may upgrade the msodbcsql17 package which requires accepting the terms and conditions. ACCEPT_EULA=Y resolves this.