### PR TITLE
Set loader consumer AUTO_OFFSET_RESET_CONFIG to earliest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,6 @@
 
 # VSCode
 **/.vscode/
+
+hapi-loader/
+app/

--- a/hapi-loader/src/main/java/com/arkhn/hapi/loader/KafkaConsumerConfig.java
+++ b/hapi-loader/src/main/java/com/arkhn/hapi/loader/KafkaConsumerConfig.java
@@ -30,6 +30,7 @@ public class KafkaConsumerConfig {
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, MessageDeserializer.class);
         props.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, 30000);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         return new DefaultKafkaConsumerFactory<>(props);
     }
 


### PR DESCRIPTION
Default is `latest`, which makes the consumer miss the first events