### PR TITLE
chore: enable uwsgi socket in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,10 @@ COPY --chown=uwsgi:uwsgi tests /srv/tests
 COPY --chown=uwsgi:uwsgi tox.ini /srv/tox.ini
 RUN chmod +x docker-entrypoint.sh
 
-ENV FILES_ROOT /var/www
-RUN mkdir -p "${FILES_ROOT}"
-RUN chown uwsgi:uwsgi "${FILES_ROOT}"
+RUN mkdir -p /var/www/static
+RUN chown uwsgi:uwsgi /var/www/static
+
+VOLUME /var/www/static
 
 USER uwsgi
 EXPOSE 8000

--- a/django/river/settings/base.py
+++ b/django/river/settings/base.py
@@ -29,6 +29,11 @@ SECRET_KEY = os.environ.get("SECRET_KEY")
 #   * it disables security checks (e.g. authorizes empty ALLOWED_HOSTS)
 DEBUG = os.environ.get("DEBUG", False) == "True"
 
+# https://docs.djangoproject.com/en/3.2/ref/settings/#use-x-forwarded-host
+# Behind a proxy, use the actual host as defined by the proxy. This is needed to
+# properly build urls.
+USE_X_FORWARDED_HOST = os.environ.get("USE_X_FORWARDED_HOST", False)
+
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS") and os.environ.get("ALLOWED_HOSTS").split(",") or []
 
 ADMIN_ENABLED = os.environ.get("ADMIN_ENABLED", False)

--- a/django/river/settings/base.py
+++ b/django/river/settings/base.py
@@ -159,7 +159,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
-STATIC_URL = "/static/"
+STATIC_URL = os.environ.get("STATIC_URL", "/static/")
 STATIC_ROOT = Path(os.environ.get("STATIC_ROOT", "var/www/static"))
 
 

--- a/django/river/settings/prod.py
+++ b/django/river/settings/prod.py
@@ -4,4 +4,7 @@ from .base import *
 #   will be removed once authencation is setup globally.
 REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = ["rest_framework.permissions.AllowAny"]
 
+# https://docs.djangoproject.com/en/3.2/ref/settings/#use-x-forwarded-host
+# Behind a proxy, use the actual host as defined by the proxy. This is needed to
+# properly build urls.
 USE_X_FORWARDED_HOST = os.environ.get("USE_X_FORWARDED_HOST", True)

--- a/django/river/settings/prod.py
+++ b/django/river/settings/prod.py
@@ -3,8 +3,3 @@ from .base import *
 # TODO: Requests should be authenticated. The following is a temporary workaround that
 #   will be removed once authencation is setup globally.
 REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = ["rest_framework.permissions.AllowAny"]
-
-# https://docs.djangoproject.com/en/3.2/ref/settings/#use-x-forwarded-host
-# Behind a proxy, use the actual host as defined by the proxy. This is needed to
-# properly build urls.
-USE_X_FORWARDED_HOST = os.environ.get("USE_X_FORWARDED_HOST", True)

--- a/django/river/settings/prod.py
+++ b/django/river/settings/prod.py
@@ -3,3 +3,5 @@ from .base import *
 # TODO: Requests should be authenticated. The following is a temporary workaround that
 #   will be removed once authencation is setup globally.
 REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = ["rest_framework.permissions.AllowAny"]
+
+USE_X_FORWARDED_HOST = os.environ.get("USE_X_FORWARDED_HOST", True)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,6 +21,15 @@ else
   else
     export UWSGI_PROCESSES=${UWSGI_PROCESSES:-5}
     export UWSGI_THREADS=${UWSGI_THREADS:-4}
+
+    # Keep using http protocol by default
+    # TODO(vmttn): drop http. This require updating the deployment to make sure
+    #   consuming services use the reverse proxy to communicate.
+    if [[ ! -z "${UWSGI_USE_SOCKET}" ]]; then
+      export UWSGI_SOCKET=0.0.0.0:8000
+    else
+      export UWSGI_HTTP=0.0.0.0:8000
+    fi
     python django/manage.py check --deploy
     uwsgi --ini uwsgi.ini
   fi

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,8 +8,7 @@ chdir = %(base)
 module = %(project).wsgi
 master = True
 
-# TODO(vmttn): use wsgi protocol instead of http
-http = 0.0.0.0:8000
+socket = 0.0.0.0:8000
 
 # clear env on exit
 vacuum = True

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,7 +8,5 @@ chdir = %(base)
 module = %(project).wsgi
 master = True
 
-socket = 0.0.0.0:8000
-
 # clear env on exit
 vacuum = True


### PR DESCRIPTION
## Fixes
In prod, allow to tell upstream (i.e. pyrog-api) that it is been served behind a proxy under a subpath
