### PR TITLE
chore: namespace cookies

### DIFF
--- a/django/river/settings/base.py
+++ b/django/river/settings/base.py
@@ -217,6 +217,18 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
 }
 
+# Sessions
+# https://docs.djangoproject.com/en/3.2/ref/settings/#sessions
+
+# Namespace cookie names to prevent clashes when working behind a proxy which
+# serves multiple services.
+SESSION_COOKIE_NAME = os.environ.get("SESSION_COOKIE_NAME", "pyrog_sessionid")
+
+# CSRF
+
+CSRF_COOKIE_NAME = os.environ.get("CSRF_COOKIE_NAME", "pyrog_csrftoken")
+
+
 # Redis
 
 REDIS_COUNTER_HOST = os.environ.get("REDIS_COUNTER_HOST", "redis")


### PR DESCRIPTION
## Description
When working behind a proxy, cookies are shared by the services available through that proxy.
Cookies with the same name will be overridden (e.g. session, csrf cookies), which is problematic.
The way to to deal with that is either to use different DNS entry for the each services (straightforward in SaaS context) or simply to namespace cookies.

## Technical details
* Prefix cookie names with `pyrog_` by default, but allow to be overridden through env
* Should logout users when rolling out this change