### PR TITLE
Fix bytes serde

### DIFF
--- a/django/common/kafka/producer.py
+++ b/django/common/kafka/producer.py
@@ -15,6 +15,12 @@ class CustomJSONEncoder(json.JSONEncoder):
             return float(obj)
         if isinstance(obj, (datetime.date, datetime.datetime)):
             return obj.isoformat()
+        if isinstance(obj, bytes):
+            # Python doesn't know how to serialize bytes
+            # We arbitrarily choose utf-8. Note that if we need to decode bytes another
+            # way, we'll need to use a cleaning script that basically does
+            # val.encode("utf-8").decode("<your-encoding>")
+            return obj.decode("utf-8")
         return super().default(obj)
 
 

--- a/django/common/kafka/producer.py
+++ b/django/common/kafka/producer.py
@@ -16,6 +16,7 @@ class CustomJSONEncoder(json.JSONEncoder):
         if isinstance(obj, (datetime.date, datetime.datetime)):
             return obj.isoformat()
         if isinstance(obj, bytes):
+            # FIXME: this should be done differently, issue #376
             # Python doesn't know how to serialize bytes
             # We arbitrarily choose utf-8. Note that if we need to decode bytes another
             # way, we'll need to use a cleaning script that basically does

--- a/django/control/api/views.py
+++ b/django/control/api/views.py
@@ -16,7 +16,7 @@ import redis
 import scripts
 from common.analyzer import Analyzer
 from common.database_connection.db_connection import DBConnection
-from common.kafka.producer import Producer
+from common.kafka.producer import CustomJSONEncoder, Producer
 from common.mapping.fetch_mapping import fetch_resource_mapping
 from confluent_kafka import KafkaException
 from confluent_kafka.admin import AdminClient, NewTopic
@@ -180,6 +180,9 @@ class PreviewEndpoint(viewsets.ViewSet):
         errors = []
         transformer = Transformer()
         for row in extractor.split_dataframe(df, analysis):
+            # Encode and decode the row to mimic what happens when events are serialized
+            # to pass through kafka
+            row = json.JSONDecoder().decode(CustomJSONEncoder().encode(row))
             primary_key_value = row[analysis.primary_key_column.dataframe_column_name()][0]
             transformed_data = transformer.transform_data(row, analysis, primary_key_value)
             document = transformer.create_fhir_document(transformed_data, analysis, primary_key_value)

--- a/tests/common/test_json_encoder.py
+++ b/tests/common/test_json_encoder.py
@@ -1,7 +1,14 @@
 from datetime import date, datetime
 from decimal import Decimal
+from unittest import mock
+
+from django.urls import reverse
 
 from common.kafka.producer import CustomJSONEncoder
+
+
+def mock_get_script(_name):
+    return lambda arg: arg.encode("utf-8").decode("unicode_escape")
 
 
 def test_encode_decimal():
@@ -18,3 +25,77 @@ def test_encode_datetime():
 
     encoded = CustomJSONEncoder().default(datetime(2020, 10, 10, 12, 12, 12))
     assert encoded == "2020-10-10T12:12:12"
+
+
+# @mock.patch("control.api.views.redis.Redis", return_value=fakeredis.FakeStrictRedis())
+@mock.patch("control.api.views.Extractor")
+@mock.patch("control.api.views.fetch_resource_mapping")
+@mock.patch("common.analyzer.cleaning_script.scripts.get_script", mock_get_script)
+def test_serde_and_clean_bytes(mock_fetch_mapping, mock_extractor, api_client):
+    extractor = mock.MagicMock()
+    extractor.split_dataframe.return_value = [
+        {
+            "doc_crid_fdce888f": [123],
+            "doc_cr_d890320c": [b"Il est rest\\xe9 \\xe0 jeun."],
+        }
+    ]
+    mock_extractor.return_value = extractor
+    mock_fetch_mapping.return_value = {
+        "id": "ckdyl65kh0125gu9kpvjbja6j",
+        "logicalReference": "415e76f4-44f4-4a19-942d-7550ea9f4161",
+        "definitionId": "DocumentReference",
+        "filters": [],
+        "primaryKeyOwner": {"name": "mimiciii"},
+        "primaryKeyTable": "doc",
+        "primaryKeyColumn": "crid",
+        "source": {
+            "id": "ckdyl65ip0010gu9k22w8kvc1",
+            "credential": {
+                "owner": None,
+                "model": "POSTGRES",
+                "login": "login",
+                "password": "password",
+                "host": "host",
+                "port": "10",
+                "database": "database",
+            },
+        },
+        "attributes": [
+            {
+                "path": "description",
+                "sliceName": None,
+                "definitionId": "string",
+                "inputGroups": [
+                    {
+                        "id": "ckdyl65kh0127gu9kqdxatrks",
+                        "mergingScript": None,
+                        "attributeId": "ckdyl65kh0126gu9ka6svbibj",
+                        "inputs": [
+                            {
+                                "script": "clean",
+                                "conceptMapId": None,
+                                "staticValue": None,
+                                "sqlValue": {
+                                    "table": "doc",
+                                    "owner": {"name": "mimiciii"},
+                                    "column": "cr",
+                                    "joins": [],
+                                },
+                            }
+                        ],
+                        "conditions": [],
+                    }
+                ],
+            },
+        ],
+        "definition": {"id": "Patient", "type": "DocumentReference"},
+    }
+
+    url = reverse("preview-list")
+    data = {
+        "resource_id": "foo",
+        "primary_key_values": ["PK"],
+    }
+    response = api_client.post(url, data=data, format="json")
+    assert response.status_code == 200
+    assert response.data["instances"][0]["description"] == "Il est resté à jeun."

--- a/tests/common/test_json_encoder.py
+++ b/tests/common/test_json_encoder.py
@@ -27,7 +27,6 @@ def test_encode_datetime():
     assert encoded == "2020-10-10T12:12:12"
 
 
-# @mock.patch("control.api.views.redis.Redis", return_value=fakeredis.FakeStrictRedis())
 @mock.patch("control.api.views.Extractor")
 @mock.patch("control.api.views.fetch_resource_mapping")
 @mock.patch("common.analyzer.cleaning_script.scripts.get_script", mock_get_script)


### PR DESCRIPTION
Pain point: the cleaning scripts has to look like `v.encode("utf-8").decode(...)`

Other solution I can see: augment the mapping with a encoding for byte values