### PR TITLE
feat(ci): use testy-action from docker-hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
         run: echo "::set-output name=docker-version::sha-${GITHUB_SHA::7}"
 
       - name: Provision, deploy and test
-        uses: arkhn/testy-action@v0.5.5
+        uses: docker://arkhn/testy-action:0.5.6
         with:
           cloudToken: ${{ secrets.TESTY_CLOUD_TOKEN }}
           cloudProjectId: ${{ secrets.TESTY_CLOUD_PROJECT_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,7 @@ jobs:
           cloudKey: ${{ secrets.TESTY_CLOUD_KEY }}
           contextName: river-ci-${{ github.sha }}
           deploymentToken: ${{ secrets.GIT_USER_KEY }}
+          deploymentRef: main
           versions: |
             {
               "fhir_river": "${{ steps.docker-tag.outputs.docker-version }}",


### PR DESCRIPTION
To gain a precious few minutes, we want to use the testy-action image from the hub.
[cf doc](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses)