### PR TITLE
feat(app): template index.html using env variables

### DIFF
--- a/app/.env.development
+++ b/app/.env.development
@@ -1,3 +1,2 @@
 REACT_APP_API_URL=http://localhost:8000
 REACT_APP_OIDC_LOGIN_URL=http://localhost:8000/oidc/authenticate/
-REACT_APP_OIDC_LOGOUT_URL=http://localhost:8000/oidc/logout/

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -5,6 +5,7 @@ COPY ./package.json .
 COPY ./yarn.lock .
 RUN yarn
 COPY . .
+RUN yarn build
 
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,11 +1,22 @@
 FROM node:15.3.0 as builder
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
+
 COPY ./package.json .
 COPY ./yarn.lock .
 RUN yarn
-COPY . .
+
+COPY ./tsconfig.json .
+COPY src src
+COPY public public
+
 RUN yarn build
+
+FROM alpine:3.13
+
+WORKDIR /app
+
+COPY --from=builder /app/build /app/build
 
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -13,7 +13,6 @@ sed -i \
     -e "s|{{PUBLIC_URL}}|$PUBLIC_URL|g" \
     -e "s|{{API_URL}}|$API_URL|g" \
     -e "s|{{OIDC_LOGIN_URL}}|$OIDC_LOGIN_URL|g" \
-    -e "s|{{OIDC_LOGOUT_URL}}|$OIDC_LOGOUT_URL|g" \
     -e "s|{{CSRF_COOKIE_NAME}}|$CSRF_COOKIE_NAME|g" \
     ./build/index.html
 

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -10,11 +10,11 @@ export STATIC_ROOT="${STATIC_ROOT:-/var/www/static/pyrog-app}"
 
 # template build/index.html using environment variables
 sed -i \
-    -e "s/{{PUBLIC_URL}}/$PUBLIC_URL/g" \
-    -e "s/{{API_URL}}/$API_URL/g" \
-    -e "s/{{OIDC_LOGIN_URL}}/$OIDC_LOGIN_URL/g" \
-    -e "s/{{OIDC_LOGOUT_URL}}/$OIDC_LOGOUT_URL/g" \
-    -e "s/{{CSRF_COOKIE_NAME}}/$CSRF_COOKIE_NAME/g" \
+    -e "s|{{PUBLIC_URL}}|$PUBLIC_URL|g" \
+    -e "s|{{API_URL}}|$API_URL|g" \
+    -e "s|{{OIDC_LOGIN_URL}}|$OIDC_LOGIN_URL|g" \
+    -e "s|{{OIDC_LOGOUT_URL}}|$OIDC_LOGOUT_URL|g" \
+    -e "s|{{CSRF_COOKIE_NAME}}|$CSRF_COOKIE_NAME|g" \
     ./build/index.html
 
 rm -rf "${STATIC_ROOT}" && cp -r ./build "${STATIC_ROOT}"

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
@@ -9,7 +9,11 @@ set -e
 export STATIC_ROOT="${STATIC_ROOT:-/var/www/static/pyrog-app}"
 
 # template build/index.html using environment variables
-sed -i -e "s/{{REACT_APP_API_URL}}/$REACT_APP_API_URL/g" \
+sed -i \
+    -e "s/{{API_URL}}/$API_URL/g" \
+    -e "s/{{OIDC_LOGIN_URL}}/$OIDC_LOGIN_URL/g" \
+    -e "s/{{OIDC_LOGOUT_URL}}/$OIDC_LOGOUT_URL/g" \
+    -e "s/{{CSRF_COOKIE_NAME}}/$CSRF_COOKIE_NAME/g" \
     ./build/index.html
 
 rm -rf "${STATIC_ROOT}" && cp -r ./build "${STATIC_ROOT}"

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -9,4 +9,9 @@ set -e
 export STATIC_ROOT="${STATIC_ROOT:-/var/www/static/pyrog-app}"
 
 yarn build
+
+# template build/index.html using environment variables
+sed -i -e "s/{{REACT_APP_API_URL}}/$REACT_APP_API_URL/g" \
+    ./build/index.html
+
 rm -rf "${STATIC_ROOT}" && cp -r ./build "${STATIC_ROOT}"

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -8,8 +8,6 @@ set -e
 
 export STATIC_ROOT="${STATIC_ROOT:-/var/www/static/pyrog-app}"
 
-yarn build
-
 # template build/index.html using environment variables
 sed -i -e "s/{{REACT_APP_API_URL}}/$REACT_APP_API_URL/g" \
     ./build/index.html

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -10,6 +10,7 @@ export STATIC_ROOT="${STATIC_ROOT:-/var/www/static/pyrog-app}"
 
 # template build/index.html using environment variables
 sed -i \
+    -e "s/{{PUBLIC_URL}}/$PUBLIC_URL/g" \
     -e "s/{{API_URL}}/$API_URL/g" \
     -e "s/{{OIDC_LOGIN_URL}}/$OIDC_LOGIN_URL/g" \
     -e "s/{{OIDC_LOGOUT_URL}}/$OIDC_LOGOUT_URL/g" \

--- a/app/package.json
+++ b/app/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "version": "0.1.0",
   "private": true,
+  "homepage": "/new_pyrog",
   "dependencies": {
     "@ahryman40k/ts-fhir-types": "^4.0.34",
     "@arkhn/ui": "^1.11.2",

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -36,7 +36,6 @@
       PUBLIC_URL: "{{PUBLIC_URL}}",
       API_URL: "{{API_URL}}",
       OIDC_LOGIN_URL: "{{OIDC_LOGIN_URL}}",
-      OIDC_LOGOUT_URL: "{{OIDC_LOGOUT_URL}}",
       CSRF_COOKIE_NAME: "{{CSRF_COOKIE_NAME}}",
     };
   </script>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -28,7 +28,10 @@
   </head>
   <script>
     window.env = {
-      API_URL: "{{REACT_APP_API_URL}}",
+      API_URL: "{{API_URL}}",
+      OIDC_LOGIN_URL: "{{OIDC_LOGIN_URL}}",
+      OIDC_LOGOUT_URL: "{{OIDC_LOGOUT_URL}}",
+      CSRF_COOKIE_NAME: "{{CSRF_COOKIE_NAME}}",
     };
   </script>
   <body>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -26,6 +26,11 @@
     -->
     <title>React Redux App</title>
   </head>
+  <script>
+    window.env = {
+      API_URL: "{{REACT_APP_API_URL}}",
+    };
+  </script>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -26,6 +26,11 @@
     -->
     <title>React Redux App</title>
   </head>
+    <!--
+       the following templated variables will be updated dynamically
+       based on environment variables when using a production build.
+       Check the docker-entrypoint.sh to understand how this is done.
+     -->
   <script>
     window.env = {
       PUBLIC_URL: "{{PUBLIC_URL}}",

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -28,6 +28,7 @@
   </head>
   <script>
     window.env = {
+      PUBLIC_URL: "{{PUBLIC_URL}}",
       API_URL: "{{API_URL}}",
       OIDC_LOGIN_URL: "{{OIDC_LOGIN_URL}}",
       OIDC_LOGOUT_URL: "{{OIDC_LOGOUT_URL}}",

--- a/app/src/app/routes/Router.tsx
+++ b/app/src/app/routes/Router.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter, Route, Switch } from "react-router-dom";
 
 import CreateMapping from "features/Mappings/Create/CreateMapping";
 
+import { PUBLIC_URL } from "../../constants";
 import AppBar from "./AppBar";
 import Mapping from "./Mapping";
 import PageNotFound from "./PageNotFound";
@@ -20,7 +21,7 @@ const useStyles = makeStyles((theme) => ({
 const Router = (): JSX.Element => {
   const classes = useStyles();
   return (
-    <BrowserRouter basename={process.env.PUBLIC_URL}>
+    <BrowserRouter basename={PUBLIC_URL}>
       <AppBar />
       <div className={classes.body}>
         <Switch>

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,5 +1,6 @@
 type EnhancedWindow = typeof window & {
   env: {
+    PUBLIC_URL: string;
     API_URL?: string;
     OIDC_LOGIN_URL?: string;
     OIDC_LOGOUT_URL?: string;
@@ -8,6 +9,7 @@ type EnhancedWindow = typeof window & {
 };
 
 let {
+  PUBLIC_URL,
   REACT_APP_API_URL: API_URL,
   REACT_APP_OIDC_LOGIN_URL: OIDC_LOGIN_URL,
   REACT_APP_OIDC_LOGOUT_URL: OIDC_LOGOUT_URL,
@@ -17,6 +19,7 @@ let {
 // when using the app with a production build, environment variables are templated in index.html.
 if (process.env.NODE_ENV === "production") {
   ({
+    PUBLIC_URL,
     API_URL,
     OIDC_LOGIN_URL,
     OIDC_LOGOUT_URL,
@@ -24,4 +27,10 @@ if (process.env.NODE_ENV === "production") {
   } = (window as EnhancedWindow).env);
 }
 
-export { API_URL, OIDC_LOGIN_URL, OIDC_LOGOUT_URL, CSRF_COOKIE_NAME };
+export {
+  PUBLIC_URL,
+  API_URL,
+  OIDC_LOGIN_URL,
+  OIDC_LOGOUT_URL,
+  CSRF_COOKIE_NAME,
+};

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -7,14 +7,21 @@ type EnhancedWindow = typeof window & {
   };
 };
 
-(window as EnhancedWindow).env =
-  process.env.NODE_ENV == "development"
-    ? (process.env as any)
-    : (window as EnhancedWindow).env;
+let {
+  REACT_APP_API_URL: API_URL,
+  REACT_APP_OIDC_LOGIN_URL: OIDC_LOGIN_URL,
+  REACT_APP_OIDC_LOGOUT_URL: OIDC_LOGOUT_URL,
+  REACT_APP_CSRF_COOKIE_NAME: CSRF_COOKIE_NAME,
+} = process.env;
 
-export const {
-  API_URL,
-  OIDC_LOGIN_URL,
-  OIDC_LOGOUT_URL,
-  CSRF_COOKIE_NAME,
-} = (window as EnhancedWindow).env;
+// when using the app with a production build, environment variables are templated in index.html.
+if (process.env.NODE_ENV === "production") {
+  ({
+    API_URL,
+    OIDC_LOGIN_URL,
+    OIDC_LOGOUT_URL,
+    CSRF_COOKIE_NAME,
+  } = (window as EnhancedWindow).env);
+}
+
+export { API_URL, OIDC_LOGIN_URL, OIDC_LOGOUT_URL, CSRF_COOKIE_NAME };

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -3,7 +3,6 @@ type EnhancedWindow = typeof window & {
     PUBLIC_URL: string;
     API_URL?: string;
     OIDC_LOGIN_URL?: string;
-    OIDC_LOGOUT_URL?: string;
     CSRF_COOKIE_NAME?: string;
   };
 };
@@ -12,7 +11,6 @@ let {
   PUBLIC_URL,
   REACT_APP_API_URL: API_URL,
   REACT_APP_OIDC_LOGIN_URL: OIDC_LOGIN_URL,
-  REACT_APP_OIDC_LOGOUT_URL: OIDC_LOGOUT_URL,
   REACT_APP_CSRF_COOKIE_NAME: CSRF_COOKIE_NAME,
 } = process.env;
 
@@ -22,15 +20,8 @@ if (process.env.NODE_ENV === "production") {
     PUBLIC_URL,
     API_URL,
     OIDC_LOGIN_URL,
-    OIDC_LOGOUT_URL,
     CSRF_COOKIE_NAME,
   } = (window as EnhancedWindow).env);
 }
 
-export {
-  PUBLIC_URL,
-  API_URL,
-  OIDC_LOGIN_URL,
-  OIDC_LOGOUT_URL,
-  CSRF_COOKIE_NAME,
-};
+export { PUBLIC_URL, API_URL, OIDC_LOGIN_URL, CSRF_COOKIE_NAME };

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,0 +1,20 @@
+type EnhancedWindow = typeof window & {
+  env: {
+    API_URL?: string;
+    OIDC_LOGIN_URL?: string;
+    OIDC_LOGOUT_URL?: string;
+    CSRF_COOKIE_NAME?: string;
+  };
+};
+
+(window as EnhancedWindow).env =
+  process.env.NODE_ENV == "development"
+    ? (process.env as any)
+    : (window as EnhancedWindow).env;
+
+export const {
+  API_URL,
+  OIDC_LOGIN_URL,
+  OIDC_LOGOUT_URL,
+  CSRF_COOKIE_NAME,
+} = (window as EnhancedWindow).env;

--- a/app/src/serviceWorker.ts
+++ b/app/src/serviceWorker.ts
@@ -10,10 +10,12 @@
 // To learn more about the benefits of this model and instructions on how to
 // opt-in, read https://bit.ly/CRA-PWA
 
+import { PUBLIC_URL } from "./constants";
+
 const isLocalhost = Boolean(
-  window.location.hostname === 'localhost' ||
+  window.location.hostname === "localhost" ||
     // [::1] is the IPv6 localhost address.
-    window.location.hostname === '[::1]' ||
+    window.location.hostname === "[::1]" ||
     // 127.0.0.0/8 are considered localhost for IPv4.
     window.location.hostname.match(
       /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
@@ -26,9 +28,9 @@ type Config = {
 };
 
 export function register(config?: Config) {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+  if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
+    const publicUrl = new URL(PUBLIC_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
@@ -36,8 +38,8 @@ export function register(config?: Config) {
       return;
     }
 
-    window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+    window.addEventListener("load", () => {
+      const swUrl = `${PUBLIC_URL}/service-worker.js`;
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.
@@ -47,8 +49,8 @@ export function register(config?: Config) {
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
           console.log(
-            'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://bit.ly/CRA-PWA'
+            "This web app is being served cache-first by a service " +
+              "worker. To learn more, visit https://bit.ly/CRA-PWA"
           );
         });
       } else {
@@ -62,21 +64,21 @@ export function register(config?: Config) {
 function registerValidSW(swUrl: string, config?: Config) {
   navigator.serviceWorker
     .register(swUrl)
-    .then(registration => {
+    .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker == null) {
           return;
         }
         installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed') {
+          if (installingWorker.state === "installed") {
             if (navigator.serviceWorker.controller) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
               console.log(
-                'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
+                "New content is available and will be used when all " +
+                  "tabs for this page are closed. See https://bit.ly/CRA-PWA."
               );
 
               // Execute callback
@@ -87,7 +89,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              console.log("Content is cached for offline use.");
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -98,25 +100,25 @@ function registerValidSW(swUrl: string, config?: Config) {
         };
       };
     })
-    .catch(error => {
-      console.error('Error during service worker registration:', error);
+    .catch((error) => {
+      console.error("Error during service worker registration:", error);
     });
 }
 
 function checkValidServiceWorker(swUrl: string, config?: Config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl, {
-    headers: { 'Service-Worker': 'script' },
+    headers: { "Service-Worker": "script" },
   })
-    .then(response => {
+    .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get('content-type');
+      const contentType = response.headers.get("content-type");
       if (
         response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
+        (contentType != null && contentType.indexOf("javascript") === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
+        navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -128,18 +130,18 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
     })
     .catch(() => {
       console.log(
-        'No internet connection found. App is running in offline mode.'
+        "No internet connection found. App is running in offline mode."
       );
     });
 }
 
 export function unregister() {
-  if ('serviceWorker' in navigator) {
+  if ("serviceWorker" in navigator) {
     navigator.serviceWorker.ready
-      .then(registration => {
+      .then((registration) => {
         registration.unregister();
       })
-      .catch(error => {
+      .catch((error) => {
         console.error(error.message);
       });
   }

--- a/app/src/services/api/apiBaseQuery.ts
+++ b/app/src/services/api/apiBaseQuery.ts
@@ -1,11 +1,7 @@
 import { fetchBaseQuery } from "@reduxjs/toolkit/query";
 import Cookies from "js-cookie";
 
-import { OIDC_LOGIN_URL } from "services/oidc/urls";
-
-import { API_URL } from "./urls";
-
-const { REACT_APP_CSRF_COOKIE_NAME: CSRF_COOKIE_NAME } = process.env;
+import { API_URL, CSRF_COOKIE_NAME, OIDC_LOGIN_URL } from "../../constants";
 
 const baseQuery = fetchBaseQuery({
   baseUrl: API_URL,

--- a/app/src/services/api/urls.ts
+++ b/app/src/services/api/urls.ts
@@ -1,8 +1,0 @@
-let API_URL = "" as string | undefined;
-if (process.env.NODE_ENV === "production") {
-  ({ REACT_APP_API_URL: API_URL } = (window as any).env);
-} else {
-  ({ REACT_APP_API_URL: API_URL } = process.env);
-}
-
-export { API_URL };

--- a/app/src/services/api/urls.ts
+++ b/app/src/services/api/urls.ts
@@ -1,1 +1,8 @@
-export const { REACT_APP_API_URL: API_URL } = process.env;
+let API_URL = "" as string | undefined;
+if (process.env.NODE_ENV === "production") {
+  ({ REACT_APP_API_URL: API_URL } = (window as any).env);
+} else {
+  ({ REACT_APP_API_URL: API_URL } = process.env);
+}
+
+export { API_URL };

--- a/app/src/services/oidc/urls.ts
+++ b/app/src/services/oidc/urls.ts
@@ -1,1 +1,0 @@
-export const { REACT_APP_OIDC_LOGIN_URL: OIDC_LOGIN_URL } = process.env;


### PR DESCRIPTION
this is a proposal for front-end packaging. Our goals are:
- have a single image/built app for multiple target environments (= being able to configure URL through env vars)
- stop building the app when starting the container
- have a smooth development workflow (the same as we currently have)
- avoid a complex setup (eg: splitting the logic between `deployment` and the front-end code)

I'm not sure this proposal fulfills all prerequisites (I find it a bit complex and error-prone) but I'd like to have your opinions)
thanks!