### PR TITLE
feat(api): no cache for fhir requests

### DIFF
--- a/django/pyrog/api/views.py
+++ b/django/pyrog/api/views.py
@@ -14,12 +14,13 @@ class FhirProxyView(ProxyView):
     upstream = settings.FHIR_API_URL
 
     def get_request_headers(self):
+        headers = super().get_request_headers()
+        headers["Cache-Control"] = "no-cache"
         try:
             token = self.request.session["oidc_access_token"]
+            headers["Authorization"] = f"Bearer {token}"
         except KeyError:
-            return super().get_request_headers()
-        headers = super().get_request_headers()
-        headers["Authorization"] = f"Bearer {token}"
+            pass
         return headers
 
 


### PR DESCRIPTION
## Description
This PR disables caching for every request to hapi fhir (by default, search results are cached for one minute in Hapi)
https://hapifhir.io/hapi-fhir/docs/server_jpa/configuration.html#search-result-caching