### PR TITLE
chore(vscode): enable python typechecking (again)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "python.analysis.extraPaths": [
         "./django"
     ],
+    "python.analysis.typeCheckingMode": "basic",
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
     "python.testing.nosetestsEnabled": false,


### PR DESCRIPTION
## Fixes
Vscode has switched the default python language server to pylance, which has typechecking disable by default.

## Description
Enable typechecking
