### PR TITLE
Display Expanded Arrow in array item

### DIFF
--- a/app/src/features/FhirResourceTree/TreeItem.tsx
+++ b/app/src/features/FhirResourceTree/TreeItem.tsx
@@ -59,7 +59,7 @@ const TreeItem = ({ elementNode, isArrayItem }: TreeItemProps): JSX.Element => {
               isArrayItem={elementNode.isArray}
             />
           ))
-        : !isPrimitive && <div key="stub" />}
+        : !isPrimitive && !elementNode.isArray && <></>}
     </MuiTreeItem>
   );
 };


### PR DESCRIPTION
## Description
When an array doesn't have children yet, the expand arrow in the fhir resource tree doesn't display.

![image](https://user-images.githubusercontent.com/47388675/119659664-ad49cc80-be2e-11eb-97ea-e5a1159d22e3.png)