### PR TITLE
fix(test): add cdc owner to mssql unit tests

### DIFF
--- a/tests/pagai/test_explore_multi_db.py
+++ b/tests/pagai/test_explore_multi_db.py
@@ -16,6 +16,7 @@ ALL_OWNERS_FOR_DBTYPE = {
         "guest",
         "INFORMATION_SCHEMA",
         "sys",
+        "cdc",
         "db_owner",
         "db_accessadmin",
         "db_securityadmin",


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Add cdc to unit tests microsoft sql owner, that was causing unit tests fains