### PR TITLE
fix(transformer): handle decmals when computing fhir objects ID

### DIFF
--- a/django/common/analyzer/attribute.py
+++ b/django/common/analyzer/attribute.py
@@ -1,25 +1,11 @@
 import logging
-from decimal import Decimal
 from typing import List
+
+from common.normalizers import normalize_to_bool, normalize_to_str
 
 from .input_group import InputGroup
 
 logger = logging.getLogger(__name__)
-
-
-def normalize_to_bool(value):
-    if value.lower() in ("true", "1"):
-        return True
-    elif value.lower() in ("false", "0"):
-        return False
-    raise ValueError(f"cannot cast {value} to boolean")
-
-
-def normalize_to_str(value):
-    if isinstance(value, float):
-        value = Decimal(value).normalize()
-        return format(value, "f")
-    return str(value)
 
 
 type_to_normalizer = {

--- a/django/common/normalizers/__init__.py
+++ b/django/common/normalizers/__init__.py
@@ -1,0 +1,1 @@
+from .normalizers import normalize_to_bool, normalize_to_str  # noqa

--- a/django/common/normalizers/normalizers.py
+++ b/django/common/normalizers/normalizers.py
@@ -1,0 +1,16 @@
+from decimal import Decimal
+
+
+def normalize_to_bool(value: str):
+    if value.lower() in ("true", "1"):
+        return True
+    elif value.lower() in ("false", "0"):
+        return False
+    raise ValueError(f"cannot cast {value} to boolean")
+
+
+def normalize_to_str(value):
+    if isinstance(value, float):
+        value = Decimal(value).normalize()
+        return format(value, "f")
+    return str(value)


### PR DESCRIPTION
## Fixes
We did not apply string normalization when computing fhir object IDs, which led to errors with reference binding...


## Technical details
Not sure about the `raise` statement in the normalizer, let me know what you think (and what you'd have done instead)

## Tests
- [x] unit tests
