### PR TITLE
Handle Columns creation/updates for attribute inputs

### DIFF
--- a/app/src/features/Columns/ColumnSelect.tsx
+++ b/app/src/features/Columns/ColumnSelect.tsx
@@ -120,6 +120,7 @@ const ColumnSelects = ({
           ...pendingColumn,
           table: _table,
           owner: _owner,
+          column: undefined,
         });
     }
   };

--- a/app/src/features/Columns/ColumnSelect.tsx
+++ b/app/src/features/Columns/ColumnSelect.tsx
@@ -100,7 +100,7 @@ const ColumnSelects = ({
 
   const tableOptions = getTableOptions(credentialOwners);
   const [columns, setColumns] = useState<string[]>(
-    table && table in schema ? schema[table] ?? [] : []
+    table && schema && table in schema ? schema[table] ?? [] : []
   );
 
   const isTableSelected = !!table;

--- a/app/src/features/Columns/columnSlice.ts
+++ b/app/src/features/Columns/columnSlice.ts
@@ -3,7 +3,9 @@ import { createEntityAdapter, createSlice } from "@reduxjs/toolkit";
 import type { RootState } from "app/store";
 import type { Column } from "services/api/generated/api.generated";
 
-const columnAdapter = createEntityAdapter<Partial<Column>>();
+export type PendingColumn = Partial<Column> & { pending?: boolean };
+
+const columnAdapter = createEntityAdapter<PendingColumn>();
 
 const columnSlice = createSlice({
   name: "column",

--- a/app/src/features/Mappings/Edit/EditMapping.tsx
+++ b/app/src/features/Mappings/Edit/EditMapping.tsx
@@ -38,6 +38,7 @@ import {
 } from "services/api/endpoints";
 import { apiValidationErrorFromResponse } from "services/api/errors";
 import type {
+  Column,
   ColumnRequest,
   CredentialRequest,
   FilterRequest,
@@ -145,7 +146,7 @@ const EditMapping = (): JSX.Element => {
               }).unwrap();
             } else {
               // Column is unchanged
-              return column;
+              return column as Column;
             }
           })
         );
@@ -241,7 +242,7 @@ const EditMapping = (): JSX.Element => {
               }).unwrap();
             } else {
               // Column is unchanged
-              return column;
+              return column as Column;
             }
           })
         );

--- a/app/src/services/api/generated/api.generated.ts
+++ b/app/src/services/api/generated/api.generated.ts
@@ -89,7 +89,7 @@ export const api = createApi({
     >({
       query: (queryArg) => ({
         url: `/api/columns/`,
-        params: { join: queryArg.join },
+        params: { input: queryArg.input, join: queryArg.join },
       }),
     }),
     apiColumnsCreate: build.mutation<
@@ -702,6 +702,7 @@ export type ApiBatchDestroyApiArg = {
 };
 export type ApiColumnsListApiResponse = /** status 200  */ Column[];
 export type ApiColumnsListApiArg = {
+  input?: string;
   join?: string;
 };
 export type ApiColumnsCreateApiResponse = /** status 201  */ Column;

--- a/django/pyrog/api/filters.py
+++ b/django/pyrog/api/filters.py
@@ -11,7 +11,7 @@ class CredentialFilterSet(filters.FilterSet):
 class ColumnFilterSet(filters.FilterSet):
     class Meta:
         model = models.Column
-        fields = ["join"]
+        fields = ["join", "input"]
 
 
 class JoinFilterSet(filters.FilterSet):

--- a/river-schema.yml
+++ b/river-schema.yml
@@ -217,6 +217,10 @@ paths:
       description: ''
       parameters:
       - in: query
+        name: input
+        schema:
+          type: string
+      - in: query
         name: join
         schema:
           type: string

--- a/tests/pyrog/api/test_column.py
+++ b/tests/pyrog/api/test_column.py
@@ -89,3 +89,15 @@ def test_filter_columns_by_join(api_client, join_factory, column_factory):
 
     assert response.status_code == 200
     assert {column_data["id"] for column_data in response.json()} == {column.id for column in first_join_columns}
+
+def test_filter_columns_by_input(api_client, input_factory, column_factory):
+    url = reverse("columns-list")
+
+    first_input, second_input = input_factory.create_batch(2)
+    first_input_columns = column_factory.create_batch(2, input=first_input)
+    column_factory.create_batch(2, input=second_input)
+
+    response = api_client.get(url, {"input": first_input.id})
+
+    assert response.status_code == 200
+    assert {column_data["id"] for column_data in response.json()} == {column.id for column in first_input_columns}


### PR DESCRIPTION
## Fixes

Fixes #427

## Memory leak issue

- Columns are well handled by local redux store. They are updated right after being created/updated from the django API. Unfortunately, I've spotted a memory leak issue when deleting parent resources of the column (like an attribute, an inputGroup or the Input itself) because when doing so, the column is deleted from the back-end (that's good), but it is not removed from the local store (that's not good).

I'm all ears to find a suitable solution, because wiring a `columnRemoved` action on Input deletion is not enough, as deleting any kind of parent resource will have the same consequences

## Potential Solution

- Maybe trigger a dispatch `columnRemoved` action when the Input component unmounts