### PR TITLE
[Won't be merged] Enable recurring batch orchestration

### DIFF
--- a/django/control/api/router.py
+++ b/django/control/api/router.py
@@ -5,6 +5,7 @@ from control.api import views
 # Register your API views here
 
 router = routers.SimpleRouter()
+router.register(r"mapping", views.MappingEndpoint, basename="mapping")
 router.register(r"batch", views.BatchEndpoint, basename="batch")
 router.register(r"preview", views.PreviewEndpoint, basename="preview")
 router.register(r"scripts", views.ScriptsEndpoint, basename="scripts")

--- a/django/control/api/serializers.py
+++ b/django/control/api/serializers.py
@@ -6,8 +6,14 @@ class ResourceSerializer(serializers.Serializer):
     resource_type = serializers.CharField()
 
 
+class CreateMappingSerializer(serializers.Serializer):
+    resource_ids = serializers.ListField(child=serializers.CharField())
+    mapping_id = serializers.CharField()
+
+
 class CreateBatchSerializer(serializers.Serializer):
     resources = serializers.ListField(child=ResourceSerializer())
+    mapping_id = serializers.CharField()
 
 
 class PreviewSerializer(serializers.Serializer):


### PR DESCRIPTION
I needed to add a mapping endpoint in order to fetch the mapping once at the beginning of a recurring batch
Eventually, this should be replaced by an endpoint that deals with everything related to a "recurring batch" setup (mapping, persistence, etc.) but I wanted to wait for the persistence PR

The other solution was to allow airflow to fetch mappings but I don't think we should do that