### PR TITLE
hotfix(settings): bool values from env

### DIFF
--- a/django/settings/base.py
+++ b/django/settings/base.py
@@ -20,7 +20,7 @@ def get_env_array_value(key: str, default: list = list):
 
 
 def get_env_bool_value(key: str, default: bool):
-    return os.environ.get(key) and strtobool(os.environ.get(key).lower()) or default
+    return os.environ.get(key) and bool(strtobool(os.environ.get(key).lower())) or default
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->

<img width="642" alt="Capture d’écran 2021-06-24 à 16 41 14" src="https://user-images.githubusercontent.com/34629112/123287165-d71a1000-d50e-11eb-8ad6-cb623c62aa17.png">

`strtobool` returns an integer