### PR TITLE
Set Tree title to root name

### DIFF
--- a/app/src/features/FhirResourceTree/FhirResourceTree.tsx
+++ b/app/src/features/FhirResourceTree/FhirResourceTree.tsx
@@ -137,7 +137,7 @@ const FhirResourceTree = (): JSX.Element => {
           iconSize={15}
         />
         <Typography className={classes.headerTitle} color="textPrimary">
-          {mapping?.definition_id}
+          {root?.name}
         </Typography>
         <IconButton onClick={handleAddExtensionClick} size="small">
           <Icon


### PR DESCRIPTION
## Fixes

- Set tree root name instead of `mapping.definitionId` as the title of the `FhirResourceTree`