### PR TITLE
fix(scripts): add a serializer to scripts endpoint view

### DIFF
--- a/app/src/services/api/generated/api.generated.ts
+++ b/app/src/services/api/generated/api.generated.ts
@@ -623,9 +623,9 @@ export const api = createApi({
         method: "DELETE",
       }),
     }),
-    apiScriptsRetrieve: build.query<
-      ApiScriptsRetrieveApiResponse,
-      ApiScriptsRetrieveApiArg
+    apiScriptsList: build.query<
+      ApiScriptsListApiResponse,
+      ApiScriptsListApiArg
     >({
       query: () => ({ url: `/api/scripts/` }),
     }),
@@ -1081,8 +1081,8 @@ export type ApiResourcesDestroyApiArg = {
   /** A unique value identifying this resource. */
   id: string;
 };
-export type ApiScriptsRetrieveApiResponse = unknown;
-export type ApiScriptsRetrieveApiArg = {};
+export type ApiScriptsListApiResponse = /** status 200  */ Scripts[];
+export type ApiScriptsListApiArg = {};
 export type ApiSourcesListApiResponse = /** status 200  */ Source[];
 export type ApiSourcesListApiArg = {};
 export type ApiSourcesCreateApiResponse = /** status 201  */ Source;
@@ -1392,6 +1392,11 @@ export type PatchedResourceRequest = {
   source?: string;
   primary_key_owner?: string;
 };
+export type Scripts = {
+  name: string;
+  description: string;
+  category: string;
+};
 export type Source = {
   id: string;
   name: string;
@@ -1622,7 +1627,7 @@ export const {
   useApiResourcesUpdateMutation,
   useApiResourcesPartialUpdateMutation,
   useApiResourcesDestroyMutation,
-  useApiScriptsRetrieveQuery,
+  useApiScriptsListQuery,
   useApiSourcesListQuery,
   useApiSourcesCreateMutation,
   useApiSourcesRetrieveQuery,

--- a/django/pyrog/api/views.py
+++ b/django/pyrog/api/views.py
@@ -34,7 +34,7 @@ class SourceViewSet(viewsets.ModelViewSet):
         return self.create(request)
 
     @action(detail=True, methods=["get"], serializer_class=MappingSerializer, url_path="export")
-    def export_mapping(self, request):
+    def export_mapping(self, request, pk=None):
         return self.retrieve(request)
 
     def get_queryset(self):

--- a/django/river/api/serializers.py
+++ b/django/river/api/serializers.py
@@ -20,3 +20,9 @@ class BatchSerializer(serializers.ModelSerializer):
 class PreviewSerializer(serializers.Serializer):
     resource_id = serializers.CharField()
     primary_key_values = serializers.ListField(child=serializers.CharField())
+
+
+class ScriptsSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    description = serializers.CharField(allow_blank=True)
+    category = serializers.CharField()

--- a/django/river/api/views.py
+++ b/django/river/api/views.py
@@ -82,7 +82,5 @@ class ScriptsEndpoint(generics.ListAPIView):
         for module_name, module in getmembers(scripts, ismodule):
             for script_name, script in getmembers(module, isfunction):
                 doc = getdoc(script)
-                res.append(
-                    {"name": script_name, "description": doc if doc is not None else "", "category": module_name}
-                )
+                res.append({"name": script_name, "description": doc or "", "category": module_name})
         return response.Response(res, status=status.HTTP_200_OK)

--- a/django/river/api/views.py
+++ b/django/river/api/views.py
@@ -75,10 +75,14 @@ class PreviewEndpoint(generics.CreateAPIView):
 
 
 class ScriptsEndpoint(generics.ListAPIView):
+    serializer_class = serializers.ScriptsSerializer
+
     def list(self, request, *args, **kwargs):
         res = []
         for module_name, module in getmembers(scripts, ismodule):
             for script_name, script in getmembers(module, isfunction):
                 doc = getdoc(script)
-                res.append({"name": script_name, "description": doc, "category": module_name})
+                res.append(
+                    {"name": script_name, "description": doc if doc is not None else "", "category": module_name}
+                )
         return response.Response(res, status=status.HTTP_200_OK)

--- a/river-schema.yml
+++ b/river-schema.yml
@@ -1909,7 +1909,7 @@ paths:
           description: No response body
   /api/scripts/:
     get:
-      operationId: api_scripts_retrieve
+      operationId: api_scripts_list
       description: ''
       tags:
       - api
@@ -1919,7 +1919,13 @@ paths:
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Scripts'
+          description: ''
   /api/sources/:
     get:
       operationId: api_sources_list
@@ -2992,6 +2998,19 @@ components:
       - primary_key_owner
       - primary_key_table
       - source
+    Scripts:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+      required:
+      - category
+      - description
+      - name
     Source:
       type: object
       properties:


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
The openapi generation failed on the scripts endpoint because of missing serializer class