### PR TITLE
feat(river): handle oracle service name

### DIFF
--- a/django/river/common/database_connection/db_connection.py
+++ b/django/river/common/database_connection/db_connection.py
@@ -38,6 +38,7 @@ class DBConnection:
         host = db_config["host"]
         port = db_config["port"]
         database = db_config["database"]
+        service_name = db_config.get("service")
 
         try:
             db_handler = DB_DRIVERS[model]
@@ -47,7 +48,8 @@ class DBConnection:
                 "db_config specifies the wrong database model. "
                 "Only 'POSTGRES', 'ORACLE' and 'MSSQL' are currently supported."
             )
-
+        if service_name:
+            return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={service_name}"
         return f"{db_handler}://{login}:{password}@{host}:{port}/{database}{url_suffix}"
 
     @contextmanager

--- a/django/river/common/database_connection/db_connection.py
+++ b/django/river/common/database_connection/db_connection.py
@@ -50,7 +50,7 @@ class DBConnection:
         try:
             [connection_type, target_name] = database.split(":", 1)
             if connection_type == "service":
-                return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={target_name}"
+                return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={target_name}&{url_suffix}"
         except ValueError:
             return f"{db_handler}://{login}:{password}@{host}:{port}/{database}{url_suffix}"
 

--- a/django/river/common/database_connection/db_connection.py
+++ b/django/river/common/database_connection/db_connection.py
@@ -34,7 +34,7 @@ class DBConnection:
     def build_db_url(db_config) -> str:
         """build the database connection url
 
-        In the case of a Oracle database, the database attribute may be suffixed
+        In the case of an Oracle database, the database attribute may be suffixed
         with "service:" if a service name is provided
         https://docs.sqlalchemy.org/en/14/dialects/oracle.html#dsn-vs-hostname-connections
 
@@ -61,6 +61,8 @@ class DBConnection:
             [connection_type, target_name] = database.split(":", 1)
             if connection_type == "service":
                 return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={target_name}&{url_suffix}"
+            else:
+                raise NotImplementedError
         except ValueError:
             return f"{db_handler}://{login}:{password}@{host}:{port}/{database}{url_suffix}"
 

--- a/django/river/common/database_connection/db_connection.py
+++ b/django/river/common/database_connection/db_connection.py
@@ -38,7 +38,6 @@ class DBConnection:
         host = db_config["host"]
         port = db_config["port"]
         database = db_config["database"]
-        service_name = db_config.get("service")
 
         try:
             db_handler = DB_DRIVERS[model]
@@ -48,9 +47,10 @@ class DBConnection:
                 "db_config specifies the wrong database model. "
                 "Only 'POSTGRES', 'ORACLE' and 'MSSQL' are currently supported."
             )
-        if service_name:
-            return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={service_name}"
-        return f"{db_handler}://{login}:{password}@{host}:{port}/{database}{url_suffix}"
+        [connection_type, target_name] = database.split(":", 1)
+        if connection_type == "service":
+            return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={target_name}"
+        return f"{db_handler}://{login}:{password}@{host}:{port}/{target_name}{url_suffix}"
 
     @contextmanager
     def session_scope(self):

--- a/django/river/common/database_connection/db_connection.py
+++ b/django/river/common/database_connection/db_connection.py
@@ -31,7 +31,17 @@ class DBConnection:
         self.metadata = MetaData(bind=self.engine)
 
     @staticmethod
-    def build_db_url(db_config):
+    def build_db_url(db_config) -> str:
+        """build the database connection url
+
+        In the case of a Oracle database, the database attribute may be suffixed
+        with "service:" if a service name is provided
+        https://docs.sqlalchemy.org/en/14/dialects/oracle.html#dsn-vs-hostname-connections
+
+        :param db_config: contains the credentials and the info
+        needed for the connection
+        :return: result string
+        """
         model = db_config["model"]
         login = db_config["login"]
         password = db_config["password"]

--- a/django/river/common/database_connection/db_connection.py
+++ b/django/river/common/database_connection/db_connection.py
@@ -60,9 +60,9 @@ class DBConnection:
         try:
             [connection_type, target_name] = database.split(":", 1)
             if connection_type == "service":
-                return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={target_name}&{url_suffix}"
+                return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={target_name}{url_suffix}"
             else:
-                raise NotImplementedError
+                raise NotImplementedError("db_config: bad connection type prefix in database attribute")
         except ValueError:
             return f"{db_handler}://{login}:{password}@{host}:{port}/{database}{url_suffix}"
 

--- a/django/river/common/database_connection/db_connection.py
+++ b/django/river/common/database_connection/db_connection.py
@@ -47,10 +47,12 @@ class DBConnection:
                 "db_config specifies the wrong database model. "
                 "Only 'POSTGRES', 'ORACLE' and 'MSSQL' are currently supported."
             )
-        [connection_type, target_name] = database.split(":", 1)
-        if connection_type == "service":
-            return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={target_name}"
-        return f"{db_handler}://{login}:{password}@{host}:{port}/{target_name}{url_suffix}"
+        try:
+            [connection_type, target_name] = database.split(":", 1)
+            if connection_type == "service":
+                return f"{db_handler}://{login}:{password}@{host}:{port}/?service_name={target_name}"
+        except ValueError:
+            return f"{db_handler}://{login}:{password}@{host}:{port}/{database}{url_suffix}"
 
     @contextmanager
     def session_scope(self):

--- a/tests/river/unit/common/test_db_connection.py
+++ b/tests/river/unit/common/test_db_connection.py
@@ -16,12 +16,22 @@ def test_build_db_url():
     db_string = DBConnection.build_db_url(credentials)
     assert db_string == "postgresql://login:password@localhost:port/database"
 
+    # With wrong model
+    credentials["model"] = "model"
+    with raises(ValueError, match="db_config specifies the wrong database model."):
+        DBConnection.build_db_url(credentials)
+
     # With oracle DB
     credentials["model"] = "ORACLE"
     db_string = DBConnection.build_db_url(credentials)
     assert db_string == "oracle+cx_oracle://login:password@localhost:port/database"
 
-    # With wrong model
-    credentials["model"] = "model"
-    with raises(ValueError, match="db_config specifies the wrong database model."):
+    # With a service_name
+    credentials["database"] = "service:service_name"
+    db_string = DBConnection.build_db_url(credentials)
+    assert db_string == "oracle+cx_oracle://login:password@localhost:port/?service_name=service_name"
+
+    # With a bad prefix
+    credentials["database"] = "invalid:name"
+    with raises(NotImplementedError, match="db_config: bad connection type prefix in database attribute"):
         DBConnection.build_db_url(credentials)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #499 by @nriss 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Pyrog need to handle this as well and a model migration is needed (or we could just use the `database` attribute in `credential` prefixing it with something specifying it's a service or a database name)