### PR TITLE
Pre-fill URI for reference linking

### DIFF
--- a/app/src/common/components/FhirResourceAutocomplete.tsx
+++ b/app/src/common/components/FhirResourceAutocomplete.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+
+import { Icon } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { makeStyles, TextField } from "@material-ui/core";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import clsx from "clsx";
+import { useTranslation } from "react-i18next";
+
+import { useApiValueSetsRetrieveQuery } from "services/api/endpoints";
+
+const useStyles = makeStyles((theme) => ({
+  autocomplete: {
+    maxWidth: 534,
+    color: theme.palette.text.disabled,
+  },
+  selected: {
+    fontWeight: 500,
+    color: theme.palette.text.primary,
+  },
+  autocompleteIcon: {
+    paddingLeft: theme.spacing(1),
+  },
+  icon: {
+    paddingRight: theme.spacing(1),
+    fill: theme.palette.text.disabled,
+  },
+  iconSelected: {
+    fill: theme.palette.orange.main,
+  },
+}));
+
+type FhirResourceAutocompleteProps = {
+  value: string;
+  onChange: (code: string) => void;
+};
+
+const FhirResourceAutocomplete = ({
+  value,
+  onChange,
+}: FhirResourceAutocompleteProps): JSX.Element => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const { data } = useApiValueSetsRetrieveQuery({
+    id: "resource-types",
+  });
+
+  const resourceTypesCodes = data?.expansion?.contains
+    ?.map(({ code }) => code || "")
+    .sort();
+
+  const handleValueChange = (
+    event: React.ChangeEvent<Record<string, never>>,
+    value: string
+  ) => {
+    onChange && onChange(value);
+  };
+
+  return (
+    <Autocomplete
+      className={classes.autocomplete}
+      options={resourceTypesCodes ?? []}
+      value={value}
+      onChange={handleValueChange}
+      selectOnFocus
+      openOnFocus
+      clearOnBlur
+      fullWidth
+      disableClearable
+      handleHomeEndKeys
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="outlined"
+          size="small"
+          placeholder={t("selectFhirResource")}
+          InputProps={{
+            ...params.InputProps,
+            className: clsx(params.InputProps.className, {
+              [classes.selected]: value !== "",
+            }),
+            startAdornment: (
+              <Icon
+                icon={IconNames.FLAME}
+                iconSize={15}
+                className={clsx(classes.icon, classes.autocompleteIcon, {
+                  [classes.iconSelected]: value !== "",
+                })}
+              />
+            ),
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export default FhirResourceAutocomplete;

--- a/app/src/common/hooks/useGetSelectedNode.tsx
+++ b/app/src/common/hooks/useGetSelectedNode.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+
+import { useParams } from "react-router-dom";
+
+import { useAppSelector } from "app/store";
+import {
+  ElementNode,
+  selectRoot,
+} from "features/FhirResourceTree/resourceTreeSlice";
+import { getNode } from "features/FhirResourceTree/resourceTreeUtils";
+import { useApiAttributesRetrieveQuery } from "services/api/endpoints";
+
+const useGetSelectedNode = (): ElementNode | undefined => {
+  const { attributeId } = useParams<{
+    attributeId?: string;
+  }>();
+  const {
+    data: selectedAttribute,
+    isUninitialized: isSelectedAttributeUninitialized,
+  } = useApiAttributesRetrieveQuery(
+    { id: attributeId ?? "" },
+    { skip: !attributeId }
+  );
+  const root = useAppSelector(selectRoot);
+
+  const selectedNode = useMemo(() => {
+    if (!isSelectedAttributeUninitialized && selectedAttribute && root) {
+      return getNode("path", selectedAttribute.path, root);
+    }
+  }, [selectedAttribute, root, isSelectedAttributeUninitialized]);
+
+  return selectedNode;
+};
+
+export default useGetSelectedNode;

--- a/app/src/common/hooks/useIsNodeReferenceSystemURI.ts
+++ b/app/src/common/hooks/useIsNodeReferenceSystemURI.ts
@@ -1,33 +1,24 @@
 import { useAppSelector } from "app/store";
-import { selectRoot } from "features/FhirResourceTree/resourceTreeSlice";
-import { getNode } from "features/FhirResourceTree/resourceTreeUtils";
+import {
+  ElementNode,
+  selectRoot,
+} from "features/FhirResourceTree/resourceTreeSlice";
+import { getParent } from "features/FhirResourceTree/resourceTreeUtils";
 
-import useGetSelectedNode from "./useGetSelectedNode";
-
-const useIsNodeReferenceSystemURI = (): boolean => {
+const useIsNodeReferenceSystemURI = (node?: ElementNode): boolean => {
   const root = useAppSelector(selectRoot);
-  const selectedNode = useGetSelectedNode();
-  const isNodeTypeURIAndNameSystem =
-    selectedNode?.type === "uri" && selectedNode?.name === "system";
 
-  if (root && selectedNode && isNodeTypeURIAndNameSystem) {
-    const parentNodePath = selectedNode.path.replace(/[.][^.]+$/, "");
-    const parentNode = getNode("path", parentNodePath, root);
-
-    const isParentNodeIdentifier = parentNode?.type === "Identifier";
-
-    if (parentNode && isParentNodeIdentifier) {
-      const greatParentNodePath = parentNode.path.replace(/[.][^.]+$/, "");
-      const greatParentNode = getNode("path", greatParentNodePath, root);
-
-      const isGreatParentNodeTypeReference =
-        greatParentNode?.type === "Reference";
-
-      return isGreatParentNodeTypeReference;
-    }
+  if (!root || !node || node.type !== "uri" || node.name !== "system") {
+    return false;
   }
 
-  return false;
+  const parentNode = getParent(node, root);
+  if (!parentNode || parentNode.type !== "Identifier") {
+    return false;
+  }
+
+  const greatParentNode = getParent(parentNode, root);
+  return greatParentNode?.type === "Reference";
 };
 
 export default useIsNodeReferenceSystemURI;

--- a/app/src/common/hooks/useIsNodeReferenceSystemURI.ts
+++ b/app/src/common/hooks/useIsNodeReferenceSystemURI.ts
@@ -1,0 +1,33 @@
+import { useAppSelector } from "app/store";
+import { selectRoot } from "features/FhirResourceTree/resourceTreeSlice";
+import { getNode } from "features/FhirResourceTree/resourceTreeUtils";
+
+import useGetSelectedNode from "./useGetSelectedNode";
+
+const useIsNodeReferenceSystemURI = (): boolean => {
+  const root = useAppSelector(selectRoot);
+  const selectedNode = useGetSelectedNode();
+  const isNodeTypeURIAndNameSystem =
+    selectedNode?.type === "uri" && selectedNode?.name === "system";
+
+  if (root && selectedNode && isNodeTypeURIAndNameSystem) {
+    const parentNodePath = selectedNode.path.replace(/[.][^.]+$/, "");
+    const parentNode = getNode("path", parentNodePath, root);
+
+    const isParentNodeIdentifier = parentNode?.type === "Identifier";
+
+    if (parentNode && isParentNodeIdentifier) {
+      const greatParentNodePath = parentNode.path.replace(/[.][^.]+$/, "");
+      const greatParentNode = getNode("path", greatParentNodePath, root);
+
+      const isGreatParentNodeTypeReference =
+        greatParentNode?.type === "Reference";
+
+      return isGreatParentNodeTypeReference;
+    }
+  }
+
+  return false;
+};
+
+export default useIsNodeReferenceSystemURI;

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -24,4 +24,12 @@ if (process.env.NODE_ENV === "production") {
   } = (window as EnhancedWindow).env);
 }
 
-export { PUBLIC_URL, API_URL, OIDC_LOGIN_URL, CSRF_COOKIE_NAME };
+const URI_STATIC_VALUE_PREFIX = "http://terminology.arkhn.org/";
+
+export {
+  PUBLIC_URL,
+  API_URL,
+  OIDC_LOGIN_URL,
+  CSRF_COOKIE_NAME,
+  URI_STATIC_VALUE_PREFIX,
+};

--- a/app/src/features/FhirAttributePanel/ExistingURIDialog.tsx
+++ b/app/src/features/FhirAttributePanel/ExistingURIDialog.tsx
@@ -8,7 +8,6 @@ import {
   DialogActions,
   Grid,
   makeStyles,
-  Typography,
 } from "@material-ui/core";
 import { useTranslation } from "react-i18next";
 
@@ -119,7 +118,7 @@ const ExistingURIDialog = ({
           onClick={handleClose}
           color="inherit"
         >
-          <Typography>{t("cancel")}</Typography>
+          {t("cancel")}
         </Button>
         <Button
           className={classes.button}
@@ -128,7 +127,7 @@ const ExistingURIDialog = ({
           onClick={handleSubmit}
           disabled={mapping === ""}
         >
-          <Typography>{t("confirm")}</Typography>
+          {t("confirm")}
         </Button>
       </DialogActions>
     </Dialog>

--- a/app/src/features/FhirAttributePanel/ExistingURIDialog.tsx
+++ b/app/src/features/FhirAttributePanel/ExistingURIDialog.tsx
@@ -61,23 +61,21 @@ const ExistingURIDialog = ({
       name?: string | undefined;
       value: unknown;
     }>
-  ) => {
-    setSource(event.target.value as string);
-  };
+  ) => setSource(event.target.value as string);
+
   const handleMappingChange = (
     event: React.ChangeEvent<{
       name?: string | undefined;
       value: unknown;
     }>
-  ) => {
-    setMapping(event.target.value as string);
-  };
+  ) => setMapping(event.target.value as string);
+
   const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
     const selectedMapping = mappings?.resources?.find(
       ({ id }: _Resource & { id?: string }) => id === mapping
     );
     if (selectedMapping) {
-      onSubmit((selectedMapping as _Resource & { id?: string }).id ?? "");
+      onSubmit((selectedMapping as _Resource).logical_reference ?? "");
     }
     handleClose(e);
   };

--- a/app/src/features/FhirAttributePanel/ExistingURIDialog.tsx
+++ b/app/src/features/FhirAttributePanel/ExistingURIDialog.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from "react";
+
+import {
+  Dialog,
+  DialogProps,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Grid,
+  makeStyles,
+  Typography,
+} from "@material-ui/core";
+import { useTranslation } from "react-i18next";
+
+import Button from "common/components/Button";
+import Select from "common/components/Select";
+import { useApiSourcesListQuery } from "services/api/endpoints";
+import {
+  useApiSourcesExportRetrieveQuery,
+  _Resource,
+} from "services/api/generated/api.generated";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: theme.spacing(3),
+  },
+  button: {
+    margin: theme.spacing(2),
+  },
+}));
+
+type ExistingURIDialogProps = Omit<DialogProps, "onSubmit" | "onClose"> & {
+  onSubmit: (staticValue: string) => void;
+  onClose?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+const ExistingURIDialog = ({
+  onSubmit,
+  ...props
+}: ExistingURIDialogProps): JSX.Element => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+  const [source, setSource] = useState("");
+  const [mapping, setMapping] = useState("");
+  const { data: sources } = useApiSourcesListQuery({});
+  const { data: mappings } = useApiSourcesExportRetrieveQuery(
+    { id: source ?? "" },
+    { skip: !source }
+  );
+
+  // Reset Mapping select when source changes
+  useEffect(() => {
+    setMapping("");
+  }, [source]);
+
+  const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
+    props.onClose && props.onClose(e);
+  };
+  const handleSourceChange = (
+    event: React.ChangeEvent<{
+      name?: string | undefined;
+      value: unknown;
+    }>
+  ) => {
+    setSource(event.target.value as string);
+  };
+  const handleMappingChange = (
+    event: React.ChangeEvent<{
+      name?: string | undefined;
+      value: unknown;
+    }>
+  ) => {
+    setMapping(event.target.value as string);
+  };
+  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    const selectedMapping = mappings?.resources?.find(
+      ({ id }: _Resource & { id?: string }) => id === mapping
+    );
+    if (selectedMapping) {
+      onSubmit((selectedMapping as _Resource & { id?: string }).id ?? "");
+    }
+    handleClose(e);
+  };
+
+  return (
+    <Dialog
+      maxWidth="sm"
+      PaperProps={{ className: classes.root }}
+      {...props}
+      fullWidth
+    >
+      <DialogTitle>{t("chooseExistingURI")}</DialogTitle>
+      <DialogContent>
+        <Grid container spacing={2} alignItems="center">
+          <Grid item>
+            <Select
+              value={source}
+              options={
+                sources?.map(({ name, id }) => ({ id, label: name })) ?? []
+              }
+              onChange={handleSourceChange}
+              emptyOption={t("selectSource")}
+            />
+          </Grid>
+          <Grid>
+            <Select
+              value={mapping}
+              options={
+                mappings?.resources?.map(
+                  ({
+                    label,
+                    id,
+                    definition_id,
+                  }: _Resource & { id?: string }) => ({
+                    id: id ?? "",
+                    label: label && label !== "" ? label : definition_id,
+                  })
+                ) ?? []
+              }
+              onChange={handleMappingChange}
+              emptyOption={t("selectMapping")}
+            />
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          className={classes.button}
+          disableRipple
+          onClick={handleClose}
+          color="inherit"
+        >
+          <Typography>{t("cancel")}</Typography>
+        </Button>
+        <Button
+          className={classes.button}
+          color="primary"
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={mapping === ""}
+        >
+          <Typography>{t("confirm")}</Typography>
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ExistingURIDialog;

--- a/app/src/features/FhirAttributePanel/ExistingURIDialog.tsx
+++ b/app/src/features/FhirAttributePanel/ExistingURIDialog.tsx
@@ -15,10 +15,7 @@ import { useTranslation } from "react-i18next";
 import Button from "common/components/Button";
 import Select from "common/components/Select";
 import { useApiSourcesListQuery } from "services/api/endpoints";
-import {
-  useApiSourcesExportRetrieveQuery,
-  _Resource,
-} from "services/api/generated/api.generated";
+import { useApiSourcesExportRetrieveQuery } from "services/api/generated/api.generated";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -72,10 +69,10 @@ const ExistingURIDialog = ({
 
   const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
     const selectedMapping = mappings?.resources?.find(
-      ({ id }: _Resource & { id?: string }) => id === mapping
+      ({ id }) => id === mapping
     );
     if (selectedMapping) {
-      onSubmit((selectedMapping as _Resource).logical_reference ?? "");
+      onSubmit(selectedMapping.logical_reference ?? "");
     }
     handleClose(e);
   };
@@ -104,16 +101,10 @@ const ExistingURIDialog = ({
             <Select
               value={mapping}
               options={
-                mappings?.resources?.map(
-                  ({
-                    label,
-                    id,
-                    definition_id,
-                  }: _Resource & { id?: string }) => ({
-                    id: id ?? "",
-                    label: label && label !== "" ? label : definition_id,
-                  })
-                ) ?? []
+                mappings?.resources?.map(({ label, id, definition_id }) => ({
+                  id: id ?? "",
+                  label: label && label !== "" ? label : definition_id,
+                })) ?? []
               }
               onChange={handleMappingChange}
               emptyOption={t("selectMapping")}

--- a/app/src/features/FhirAttributePanel/StaticInput.tsx
+++ b/app/src/features/FhirAttributePanel/StaticInput.tsx
@@ -92,7 +92,7 @@ const StaticInput = ({ input }: StaticInputProps): JSX.Element => {
     [mappings, mappingId]
   );
   const selectedNode = useGetSelectedNode();
-  const isNodeReferenceSystemURI = useIsNodeReferenceSystemURI();
+  const isNodeReferenceSystemURI = useIsNodeReferenceSystemURI(selectedNode);
   const isNodeTypeURI = selectedNode?.type === "uri";
   const isNodeNameType = selectedNode?.name === "type";
   const handleDeleteInput = async () => {

--- a/app/src/features/FhirAttributePanel/StaticInput.tsx
+++ b/app/src/features/FhirAttributePanel/StaticInput.tsx
@@ -26,9 +26,8 @@ import {
   useApiSourcesExportRetrieveQuery,
 } from "services/api/generated/api.generated";
 
+import { URI_STATIC_VALUE_PREFIX } from "../../constants";
 import ExistingURIDialog from "./ExistingURIDialog";
-
-const URI_STATIC_VALUE_PREFIX = "http://terminology.arkhn.org/";
 
 type StaticInputProps = {
   input: Input;
@@ -169,69 +168,73 @@ const StaticInput = ({ input }: StaticInputProps): JSX.Element => {
   };
 
   return (
-    <>
-      <Grid container item alignItems="center" direction="row" spacing={1}>
-        <Grid item container alignItems="center" xs={10} spacing={2}>
-          <Grid item xs={7}>
-            {isNodeTypeURI && isNodeNameType ? (
-              <FhirResourceAutocomplete
-                value={input.static_value ?? ""}
-                onChange={handleFhirResourceAutocompleteChange}
-              />
-            ) : (
-              <TextField
-                variant="outlined"
-                size="small"
-                fullWidth
-                placeholder={t("typeStaticValueHere")}
-                className={classes.input}
-                value={staticValue}
-                onChange={handleStaticValueChange}
-                onBlur={handleInputBlur}
-                InputProps={{
-                  startAdornment: (
-                    <Icon
-                      icon={IconNames.ALIGN_LEFT}
-                      className={clsx(classes.inputStartAdornment, {
-                        [classes.primaryColor]: !!staticValue,
-                      })}
-                    />
-                  ),
-                }}
-              />
-            )}
-          </Grid>
-          {isNodeTypeURI && !isNodeNameType && !isNodeReferenceSystemURI && (
-            <Grid item>
-              <Button variant="outlined" onClick={handleGenerateURIClick}>
-                <Typography>{t("generateURI")}</Typography>
-              </Button>
-            </Grid>
+    <Grid container item alignItems="center" direction="row" spacing={1}>
+      <Grid item container alignItems="center" xs={10} spacing={2}>
+        <Grid item xs={7}>
+          {isNodeTypeURI && isNodeNameType ? (
+            <FhirResourceAutocomplete
+              value={input.static_value ?? ""}
+              onChange={handleFhirResourceAutocompleteChange}
+            />
+          ) : (
+            <TextField
+              variant="outlined"
+              size="small"
+              fullWidth
+              placeholder={t("typeStaticValueHere")}
+              className={classes.input}
+              value={staticValue}
+              onChange={handleStaticValueChange}
+              onBlur={handleInputBlur}
+              InputProps={{
+                startAdornment: (
+                  <Icon
+                    icon={IconNames.ALIGN_LEFT}
+                    className={clsx(classes.inputStartAdornment, {
+                      [classes.primaryColor]: !!staticValue,
+                    })}
+                  />
+                ),
+              }}
+            />
           )}
-          {isNodeReferenceSystemURI && (
+        </Grid>
+        {isNodeTypeURI && !isNodeNameType && !isNodeReferenceSystemURI && (
+          <Grid item>
+            <Button
+              variant="outlined"
+              onClick={handleGenerateURIClick}
+              disabled={!currentMapping}
+            >
+              <Typography>{t("generateURI")}</Typography>
+            </Button>
+          </Grid>
+        )}
+        {isNodeReferenceSystemURI && (
+          <>
             <Grid item>
               <Button variant="outlined" onClick={handleExistingURIDialogOpen}>
                 <Typography>{t("chooseExistingURI")}</Typography>
               </Button>
             </Grid>
-          )}
-        </Grid>
-        <Grid item className={classes.iconButtonContainer}>
-          <IconButton
-            size="small"
-            className={classes.iconButton}
-            onClick={handleDeleteInput}
-          >
-            <Icon icon={IconNames.TRASH} className={classes.icon} />
-          </IconButton>
-        </Grid>
+            <ExistingURIDialog
+              open={isExistingURIDialogOpen}
+              onSubmit={handleExistingURIDialogSubmit}
+              onClose={handleExistingURIDialogClose}
+            />
+          </>
+        )}
       </Grid>
-      <ExistingURIDialog
-        open={isExistingURIDialogOpen}
-        onSubmit={handleExistingURIDialogSubmit}
-        onClose={handleExistingURIDialogClose}
-      />
-    </>
+      <Grid item className={classes.iconButtonContainer}>
+        <IconButton
+          size="small"
+          className={classes.iconButton}
+          onClick={handleDeleteInput}
+        >
+          <Icon icon={IconNames.TRASH} className={classes.icon} />
+        </IconButton>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/app/src/features/FhirAttributePanel/StaticInput.tsx
+++ b/app/src/features/FhirAttributePanel/StaticInput.tsx
@@ -2,13 +2,7 @@ import React, { useMemo, useState } from "react";
 
 import { Icon } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
-import {
-  Grid,
-  IconButton,
-  makeStyles,
-  TextField,
-  Typography,
-} from "@material-ui/core";
+import { Grid, IconButton, makeStyles, TextField } from "@material-ui/core";
 import clsx from "clsx";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
@@ -206,7 +200,7 @@ const StaticInput = ({ input }: StaticInputProps): JSX.Element => {
               onClick={handleGenerateURIClick}
               disabled={!currentMapping}
             >
-              <Typography>{t("generateURI")}</Typography>
+              {t("generateURI")}
             </Button>
           </Grid>
         )}
@@ -214,7 +208,7 @@ const StaticInput = ({ input }: StaticInputProps): JSX.Element => {
           <>
             <Grid item>
               <Button variant="outlined" onClick={handleExistingURIDialogOpen}>
-                <Typography>{t("chooseExistingURI")}</Typography>
+                {t("chooseExistingURI")}
               </Button>
             </Grid>
             <ExistingURIDialog

--- a/app/src/features/FhirAttributePanel/StaticInput.tsx
+++ b/app/src/features/FhirAttributePanel/StaticInput.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import Button from "common/components/Button";
+import FhirResourceAutocomplete from "common/components/FhirResourceAutocomplete";
 import useGetSelectedNode from "common/hooks/useGetSelectedNode";
 import {
   useApiInputsDestroyMutation,
@@ -125,46 +126,59 @@ const StaticInput = ({ input }: StaticInputProps): JSX.Element => {
     }
   };
 
+  const handleFhirResourceAutocompleteChange = async (value: string) => {
+    if (value !== input.static_value) {
+      try {
+        await updateInput({
+          id: input.id,
+          inputRequest: { ...input, static_value: value },
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  };
+
   return (
     <Grid container item alignItems="center" direction="row" spacing={1}>
-      {isNodeTypeURI && isNodeNameType ? (
-        <></>
-      ) : (
-        <>
-          <Grid item container alignItems="center" xs={10} spacing={2}>
-            <Grid item xs={7}>
-              <TextField
-                variant="outlined"
-                size="small"
-                fullWidth
-                placeholder={t("typeStaticValueHere")}
-                className={classes.input}
-                value={staticValue}
-                onChange={handleStaticValueChange}
-                onBlur={handleInputBlur}
-                InputProps={{
-                  startAdornment: (
-                    <Icon
-                      icon={IconNames.ALIGN_LEFT}
-                      className={clsx(classes.inputStartAdornment, {
-                        [classes.primaryColor]: !!staticValue,
-                      })}
-                    />
-                  ),
-                }}
-              />
-            </Grid>
-            {isNodeTypeURI && (
-              <Grid item>
-                <Button variant="outlined" onClick={handleGenerateURIClick}>
-                  {t("generateURI")}
-                </Button>
-              </Grid>
-            )}
+      <Grid item container alignItems="center" xs={10} spacing={2}>
+        <Grid item xs={7}>
+          {isNodeTypeURI && isNodeNameType ? (
+            <FhirResourceAutocomplete
+              value={input.static_value ?? ""}
+              onChange={handleFhirResourceAutocompleteChange}
+            />
+          ) : (
+            <TextField
+              variant="outlined"
+              size="small"
+              fullWidth
+              placeholder={t("typeStaticValueHere")}
+              className={classes.input}
+              value={staticValue}
+              onChange={handleStaticValueChange}
+              onBlur={handleInputBlur}
+              InputProps={{
+                startAdornment: (
+                  <Icon
+                    icon={IconNames.ALIGN_LEFT}
+                    className={clsx(classes.inputStartAdornment, {
+                      [classes.primaryColor]: !!staticValue,
+                    })}
+                  />
+                ),
+              }}
+            />
+          )}
+        </Grid>
+        {isNodeTypeURI && !isNodeNameType && (
+          <Grid item>
+            <Button variant="outlined" onClick={handleGenerateURIClick}>
+              {t("generateURI")}
+            </Button>
           </Grid>
-        </>
-      )}
-
+        )}
+      </Grid>
       <Grid item className={classes.iconButtonContainer}>
         <IconButton
           size="small"

--- a/app/src/features/FhirResourceTree/FhirResourceTree.tsx
+++ b/app/src/features/FhirResourceTree/FhirResourceTree.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 
 import { Icon } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
@@ -14,11 +14,11 @@ import { TreeView } from "@material-ui/lab";
 import clsx from "clsx";
 import { useHistory, useParams } from "react-router-dom";
 
+import useGetSelectedNode from "common/hooks/useGetSelectedNode";
 import {
   useApiAttributesCreateMutation,
   useApiResourcesRetrieveQuery,
   useApiAttributesListQuery,
-  useApiAttributesRetrieveQuery,
   useApiInputGroupsCreateMutation,
 } from "services/api/endpoints";
 
@@ -51,18 +51,10 @@ const FhirResourceTree = (): JSX.Element => {
   const classes = useStyles();
   const history = useHistory();
   const [expandedNodes, setExpandedNodes] = useState<string[]>([]);
-  const { sourceId, mappingId, attributeId } = useParams<{
+  const { sourceId, mappingId } = useParams<{
     sourceId?: string;
     mappingId?: string;
-    attributeId?: string;
   }>();
-  const {
-    data: selectedAttribute,
-    isUninitialized: isSelectedAttributeUninitialized,
-  } = useApiAttributesRetrieveQuery(
-    { id: attributeId ?? "" },
-    { skip: !attributeId }
-  );
   const { data: mapping } = useApiResourcesRetrieveQuery(
     {
       id: mappingId ?? "",
@@ -81,12 +73,7 @@ const FhirResourceTree = (): JSX.Element => {
   );
   const [createAttribute] = useApiAttributesCreateMutation();
   const [createInputGroup] = useApiInputGroupsCreateMutation();
-
-  const selectedNode = useMemo(() => {
-    if (!isSelectedAttributeUninitialized && selectedAttribute && root) {
-      return getNode("path", selectedAttribute.path, root);
-    }
-  }, [selectedAttribute, root, isSelectedAttributeUninitialized]);
+  const selectedNode = useGetSelectedNode();
 
   const handleSelectNode = async (
     _: React.ChangeEvent<unknown>,

--- a/app/src/features/FhirResourceTree/resourceTreeUtils.ts
+++ b/app/src/features/FhirResourceTree/resourceTreeUtils.ts
@@ -186,7 +186,7 @@ const isElementNodeChildOf = (child: ElementNode, parent: ElementNode) => {
   );
 };
 
-const getParent = (
+export const getParent = (
   child: ElementNode,
   root: ElementNode
 ): ElementNode | undefined => {

--- a/app/src/locales/en.json
+++ b/app/src/locales/en.json
@@ -117,5 +117,6 @@
   "resources": "Resources",
   "retry": "Retry",
   "mergingScript": "Merging script",
-  "selectScript": "Select script"
+  "selectScript": "Select script",
+  "generateURI": "Generate URI"
 }

--- a/app/src/locales/en.json
+++ b/app/src/locales/en.json
@@ -118,5 +118,8 @@
   "retry": "Retry",
   "mergingScript": "Merging script",
   "selectScript": "Select script",
-  "generateURI": "Generate URI"
+  "generateURI": "Generate URI",
+  "chooseExistingURI": "Choose existing URI",
+  "selectSource": "Select a source",
+  "selectMapping": "Select a mapping"
 }


### PR DESCRIPTION
## Fixes

- Fixes #518 

## Behaviors related values

- Behavior 1
   - The concatenated id is the logical_reference of the current mapping. Static value prefix is `http://terminology.arkhn.org/`

- Behavior 2
   - ValueSets of type `resource-types` are listed in the autocomplete component. When one is selected, the static value is the `code` attribute of the valueSet

- Behavior 3
   - The concatenated id is the logical_reference of the selected mapping from the modal. Static value prefix is `http://terminology.arkhn.org/`

## Capture

https://user-images.githubusercontent.com/12270309/126489185-f1b21be8-37f3-4a26-914f-5aaaf356b6b0.mov

