### PR TITLE
refactor(river): no default values for adapters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,8 @@ jobs:
         run: echo "::set-output name=docker-version::sha-${GITHUB_SHA::7}"
 
       - name: Provision, deploy and test
-        uses: docker://arkhn/testy-action:0.5.7
+        # uses: docker://arkhn/testy-action:0.5.7
+        uses: arkhn/testy-action@sv/missing-deployment-vars
         with:
           cloudToken: ${{ secrets.TESTY_CLOUD_TOKEN }}
           cloudProjectId: ${{ secrets.TESTY_CLOUD_PROJECT_ID }}
@@ -151,7 +152,7 @@ jobs:
           dockerUsername: ${{ secrets.DOCKER_LOGIN }}
           dockerPassword: ${{ secrets.DOCKER_PASSWORD }}
           deploymentToken: ${{ secrets.GIT_USER_KEY }}
-          deploymentRef: main
+          deploymentRef: sv/stop-pulling-testy
           debug: true
           versions: |
             {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
           dockerUsername: ${{ secrets.DOCKER_LOGIN }}
           dockerPassword: ${{ secrets.DOCKER_PASSWORD }}
           deploymentToken: ${{ secrets.GIT_USER_KEY }}
-          deploymentRef: main
+          deploymentRef: prod
           versions: |
             {
               "fhir_river": "${{ steps.docker-tag.outputs.docker-version }}",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,8 +142,7 @@ jobs:
         run: echo "::set-output name=docker-version::sha-${GITHUB_SHA::7}"
 
       - name: Provision, deploy and test
-        # uses: docker://arkhn/testy-action:0.5.7
-        uses: arkhn/testy-action@sv/missing-deployment-vars
+        uses: docker://arkhn/testy-action:0.5.8
         with:
           cloudToken: ${{ secrets.TESTY_CLOUD_TOKEN }}
           cloudProjectId: ${{ secrets.TESTY_CLOUD_PROJECT_ID }}
@@ -152,8 +151,7 @@ jobs:
           dockerUsername: ${{ secrets.DOCKER_LOGIN }}
           dockerPassword: ${{ secrets.DOCKER_PASSWORD }}
           deploymentToken: ${{ secrets.GIT_USER_KEY }}
-          deploymentRef: sv/stop-pulling-testy
-          debug: true
+          deploymentRef: main
           versions: |
             {
               "fhir_river": "${{ steps.docker-tag.outputs.docker-version }}",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,8 @@ jobs:
           dockerUsername: ${{ secrets.DOCKER_LOGIN }}
           dockerPassword: ${{ secrets.DOCKER_PASSWORD }}
           deploymentToken: ${{ secrets.GIT_USER_KEY }}
-          deploymentRef: prod
+          deploymentRef: main
+          debug: true
           versions: |
             {
               "fhir_river": "${{ steps.docker-tag.outputs.docker-version }}",

--- a/django/river/extractor/service.py
+++ b/django/river/extractor/service.py
@@ -2,10 +2,10 @@ import logging
 
 from confluent_kafka import KafkaError, KafkaException
 
-from river.adapters.event_publisher import EventPublisher, KafkaEventPublisher
-from river.adapters.event_subscriber import KafkaEventSubscriber
-from river.adapters.mappings import MappingsRepository, RedisMappingsRepository
-from river.adapters.progression_counter import ProgressionCounter, RedisProgressionCounter
+from river.adapters.event_publisher import EventPublisher
+from river.adapters.event_subscriber import EventSubscriber
+from river.adapters.mappings import MappingsRepository
+from river.adapters.progression_counter import ProgressionCounter
 from river.common.analyzer import Analyzer
 from river.common.database_connection.db_connection import DBConnection
 from river.common.service.errors import BatchCancelled
@@ -80,10 +80,10 @@ def batch_resource_handler(
 
 
 def bootstrap(
-    subscriber=KafkaEventSubscriber(group_id="extractor"),
-    mappings_repo=RedisMappingsRepository(),
-    counter=RedisProgressionCounter(),
-    publisher=KafkaEventPublisher(),
+    subscriber: EventSubscriber,
+    publisher: EventPublisher,
+    mappings_repo: MappingsRepository,
+    counter: ProgressionCounter,
 ) -> Service:
     analyzer = Analyzer()
 

--- a/django/river/management/commands/extractor.py
+++ b/django/river/management/commands/extractor.py
@@ -2,6 +2,10 @@ import logging
 
 from django.core.management.base import BaseCommand
 
+from river.adapters.event_publisher import KafkaEventPublisher
+from river.adapters.event_subscriber import KafkaEventSubscriber
+from river.adapters.mappings import RedisMappingsRepository
+from river.adapters.progression_counter import RedisProgressionCounter
 from river.extractor.service import bootstrap
 from utils.exporter import start_exporter
 
@@ -13,5 +17,7 @@ class Command(BaseCommand):
         start_exporter()
 
         logger.info("Starting...")
-        service = bootstrap()
+        service = bootstrap(
+            KafkaEventSubscriber(), KafkaEventPublisher(), RedisMappingsRepository(), RedisProgressionCounter()
+        )
         service.run()

--- a/django/river/management/commands/extractor.py
+++ b/django/river/management/commands/extractor.py
@@ -18,6 +18,9 @@ class Command(BaseCommand):
 
         logger.info("Starting...")
         service = bootstrap(
-            KafkaEventSubscriber(), KafkaEventPublisher(), RedisMappingsRepository(), RedisProgressionCounter()
+            KafkaEventSubscriber(group_id="extractor"),
+            KafkaEventPublisher(),
+            RedisMappingsRepository(),
+            RedisProgressionCounter(),
         )
         service.run()

--- a/django/river/management/commands/topicleaner.py
+++ b/django/river/management/commands/topicleaner.py
@@ -2,6 +2,8 @@ import logging
 
 from django.core.management.base import BaseCommand
 
+from river.adapters.progression_counter import RedisProgressionCounter
+from river.adapters.topics import KafkaTopicsManager
 from river.topicleaner.service import run
 
 logger = logging.getLogger(__name__)
@@ -10,4 +12,4 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     def handle(self, *args, **options):
         logger.info("Starting...")
-        run()
+        run(RedisProgressionCounter(), KafkaTopicsManager())

--- a/django/river/management/commands/transformer.py
+++ b/django/river/management/commands/transformer.py
@@ -16,5 +16,7 @@ class Command(BaseCommand):
         start_exporter()
 
         logger.info("Starting...")
-        service = bootstrap(KafkaEventSubscriber(), KafkaEventPublisher(), RedisMappingsRepository())
+        service = bootstrap(
+            KafkaEventSubscriber(group_id="transformer"), KafkaEventPublisher(), RedisMappingsRepository()
+        )
         service.run()

--- a/django/river/management/commands/transformer.py
+++ b/django/river/management/commands/transformer.py
@@ -2,6 +2,9 @@ import logging
 
 from django.core.management.base import BaseCommand
 
+from river.adapters.event_publisher import KafkaEventPublisher
+from river.adapters.event_subscriber import KafkaEventSubscriber
+from river.adapters.mappings import RedisMappingsRepository
 from river.transformer.service import bootstrap
 from utils.exporter import start_exporter
 
@@ -13,5 +16,5 @@ class Command(BaseCommand):
         start_exporter()
 
         logger.info("Starting...")
-        app = bootstrap()
-        app.run()
+        service = bootstrap(KafkaEventSubscriber(), KafkaEventPublisher(), RedisMappingsRepository())
+        service.run()

--- a/django/river/topicleaner/service.py
+++ b/django/river/topicleaner/service.py
@@ -4,8 +4,8 @@ from time import sleep
 from django.utils import timezone
 
 from river import models
-from river.adapters.progression_counter import ProgressionCounter, RedisProgressionCounter
-from river.adapters.topics import KafkaTopicsManager, TopicsManager
+from river.adapters.progression_counter import ProgressionCounter
+from river.adapters.topics import TopicsManager
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ def clean(counter: ProgressionCounter, topics: TopicsManager):
         logger.info(f"Batch {batch} deleted.")
 
 
-def run(counter=RedisProgressionCounter(), topics=KafkaTopicsManager()):
+def run(counter: ProgressionCounter, topics: TopicsManager):
     while True:
         clean(counter=counter, topics=topics)
         sleep(10)

--- a/django/river/transformer/service.py
+++ b/django/river/transformer/service.py
@@ -2,9 +2,9 @@ import logging
 
 from confluent_kafka import KafkaError, KafkaException
 
-from river.adapters.event_publisher import EventPublisher, KafkaEventPublisher
-from river.adapters.event_subscriber import KafkaEventSubscriber
-from river.adapters.mappings import MappingsRepository, RedisMappingsRepository
+from river.adapters.event_publisher import EventPublisher
+from river.adapters.event_subscriber import EventSubscriber
+from river.adapters.mappings import MappingsRepository
 from river.common.analyzer import Analyzer
 from river.common.errors import OperationOutcome
 from river.common.service.service import Service
@@ -86,9 +86,9 @@ def extracted_record_handler(
 
 
 def bootstrap(
-    subscriber=KafkaEventSubscriber(group_id="transformer"),
-    mappings_repo=RedisMappingsRepository(),
-    publisher=KafkaEventPublisher(),
+    subscriber: EventSubscriber,
+    publisher: EventPublisher,
+    mappings_repo: MappingsRepository,
 ) -> Service:
     analyzer = Analyzer()
     transformer = Transformer()


### PR DESCRIPTION
## Fixes
The issue was: when importing the module river.extractor.service, the default arguments were instanciated leading to connection issues to kafka/redis etc...
