### PR TITLE
fix(river): batch completed_at and canceled_at typing

### DIFF
--- a/django/river/api/serializers/serializers.py
+++ b/django/river/api/serializers/serializers.py
@@ -15,7 +15,11 @@ class BatchSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Batch
         exclude = ["mappings"]
-        extra_kwargs = {"resource_ids": {"required": True}}
+        extra_kwargs = {
+            "resource_ids": {"required": True},
+            "canceled_at": {"allow_null": True},
+            "completed_at": {"allow_null": True},
+        }
 
 
 class PreviewRequestSerializer(serializers.Serializer):

--- a/river-schema.yml
+++ b/river-schema.yml
@@ -2345,10 +2345,12 @@ components:
           type: string
           format: date-time
           readOnly: true
+          nullable: true
         completed_at:
           type: string
           format: date-time
           readOnly: true
+          nullable: true
       required:
       - canceled_at
       - completed_at


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
A DRF issue prevents read only attributes to be marked as nullable. The generated openapi schema showed incorrect types for the Batch model. This pr fixes this.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Related to: https://github.com/tfranzel/drf-spectacular/issues/383
