### PR TITLE
Create static input for node of type "URI" & name "type"

### DIFF
--- a/app/src/features/FhirResourceTree/FhirResourceTree.tsx
+++ b/app/src/features/FhirResourceTree/FhirResourceTree.tsx
@@ -20,6 +20,7 @@ import {
   useApiResourcesRetrieveQuery,
   useApiAttributesListQuery,
   useApiInputGroupsCreateMutation,
+  useApiInputsCreateMutation,
 } from "services/api/endpoints";
 
 import { getNode } from "./resourceTreeUtils";
@@ -73,6 +74,7 @@ const FhirResourceTree = (): JSX.Element => {
   );
   const [createAttribute] = useApiAttributesCreateMutation();
   const [createInputGroup] = useApiInputGroupsCreateMutation();
+  const [createInput] = useApiInputsCreateMutation();
   const selectedNode = useGetSelectedNode();
 
   const handleSelectNode = async (
@@ -100,7 +102,21 @@ const FhirResourceTree = (): JSX.Element => {
               resource: mapping.id,
             },
           }).unwrap();
-          createInputGroup({ inputGroupRequest: { attribute: attribute.id } });
+          const inputGroup = await createInputGroup({
+            inputGroupRequest: { attribute: attribute.id },
+          }).unwrap();
+          const isNodeTypeURI = node?.type === "uri";
+          const isNodeNameType = node?.name === "type";
+          // Create a static input for node of type "URI" & name "type"
+          if (isNodeTypeURI && isNodeNameType) {
+            createInput({
+              inputRequest: {
+                input_group: inputGroup.id,
+                static_value: "",
+              },
+            });
+          }
+
           history.push(
             `/sources/${sourceId}/mappings/${mappingId}/attributes/${attribute.id}`
           );


### PR DESCRIPTION
## Fixes

Fixes #554 

## Description
- When selecting nodes, an attribute AND an inputGroup are automatically created for its path. I've added an `if` statement to create a static input on top of this workflow only if the node is of type `URI` and its name is `type` (behavior 2 as described in #518 )

## Side note

- Basically, the behavior automation has the same behavior as for the automatically created inputGroup: it only happens ONCE, when the attribute is created (ie when the node is selected for the 1st time).

## Capture

https://user-images.githubusercontent.com/12270309/131699181-b0c6a49a-a347-4b80-b4a3-1eb73b40c135.mov



