### PR TITLE
[Preview] Compare primary keys with lower case values

### DIFF
--- a/app/src/features/Preview/Preview.tsx
+++ b/app/src/features/Preview/Preview.tsx
@@ -248,7 +248,10 @@ const Preview = (): JSX.Element => {
   const handleFhirIconClick = (index: number) => async () => {
     if (exploration && mappingId && mapping?.primary_key_column) {
       const primaryKey = mapping.primary_key_column;
-      const primaryKeyIndex = exploration.fields.indexOf(primaryKey);
+      // FIXME: See https://github.com/arkhn/fhir-river/issues/670
+      const primaryKeyIndex = exploration.fields
+        .map((field) => field.toLowerCase())
+        .indexOf(primaryKey.toLowerCase());
       const primaryKeyValue = exploration.rows[index]?.[primaryKeyIndex];
       if (primaryKeyValue) {
         const previewCreate = async () => {


### PR DESCRIPTION
## Description

Quick fix to compare the mapping `definition_id` lower case value to explorations `fields` lower case values.

## Definition of Done

- [x] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [ ] I have written tests for the code I added or updated. => NA.
- [ ] I have updated the documentation according to my changes.=> NA.
- [ ] I have updated the deployment configuration if needed.=> NA.
