### PR TITLE
fix(river-api): revoke user token before logout

### DIFF
--- a/django/utils/auth.py
+++ b/django/utils/auth.py
@@ -5,7 +5,7 @@ import requests
 
 def logout(request):
     """When logging out of river, the session is destroyed in the river app
-    but we also need to destroy he session in oprovider, otherwise the client
+    but we also need to destroy the session in oprovider, otherwise the client
     will simply silently re-login. We therefore call the logout route of oprovider.
     See https://mozilla-django-oidc.readthedocs.io/en/stable/installation.html
     log-user-out-of-the-openid-connect-provider


### PR DESCRIPTION
## Fixes

Fixes #561 

## Description

We need to call the `oprovider/o/revoke_token` route to invalidate the access token and then remove the user from the oprovider session by redirecting the browser to `/oprovider/admin/logout/`.

## Definition of Done

- [x] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [ ] I have written tests for the code I added or updated.
- [x] I have updated the documentation according to my changes.
- [x] I have updated the deployment configuration if needed.

## Tests

Tested on dev. Too hard to e2e test (sorry).