### PR TITLE
Made `Relation` required for `Condition` POST requests

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -65,7 +65,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
-    "generate:api": "npx @rtk-incubator/rtk-query-codegen-openapi --file ./src/services/api/generated/api.generated.ts --baseQuery ./src/services/api/apiBaseQuery.ts:apiBaseQuery --hooks ../river-schema.yml"
+    "generate:api": "npx @rtk-incubator/rtk-query-codegen-openapi@0.5 --file ./src/services/api/generated/api.generated.ts --baseQuery ./src/services/api/apiBaseQuery.ts:apiBaseQuery --hooks ../river-schema.yml"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/app/src/features/Conditions/useCondition.ts
+++ b/app/src/features/Conditions/useCondition.ts
@@ -45,6 +45,7 @@ const useCondition = ({
       const isConditionPartial =
         !changedCondition.action ||
         !changedCondition.sql_input ||
+        !changedCondition.relation ||
         !changedCondition.input_group;
       if (
         (!exists || condition) &&

--- a/app/src/services/api/factory.ts
+++ b/app/src/services/api/factory.ts
@@ -124,7 +124,7 @@ export const conditionFactory = Factory.define<Condition>(
     action: associations.action || "INCLUDE",
     sql_input: associations.sql_input || sqlInputFactory.build().id,
     input_group: associations.input_group || inputGroupFactory.build().id,
-    relation: associations.relation,
+    relation: associations.relation || "EQ",
     value: associations.value,
   })
 );

--- a/app/src/services/api/generated/api.generated.ts
+++ b/app/src/services/api/generated/api.generated.ts
@@ -825,8 +825,7 @@ export type ApiAttributesUpdateApiArg = {
   id: string;
   attributeRequest: AttributeRequest;
 };
-export type ApiAttributesPartialUpdateApiResponse =
-  /** status 200  */ Attribute;
+export type ApiAttributesPartialUpdateApiResponse = /** status 200  */ Attribute;
 export type ApiAttributesPartialUpdateApiArg = {
   /** A unique value identifying this attribute. */
   id: string;
@@ -932,8 +931,7 @@ export type ApiConditionsUpdateApiArg = {
   id: string;
   conditionRequest: ConditionRequest;
 };
-export type ApiConditionsPartialUpdateApiResponse =
-  /** status 200  */ Condition;
+export type ApiConditionsPartialUpdateApiResponse = /** status 200  */ Condition;
 export type ApiConditionsPartialUpdateApiArg = {
   /** A unique value identifying this condition. */
   id: string;
@@ -967,8 +965,7 @@ export type ApiCredentialsUpdateApiArg = {
   id: string;
   credentialRequest: CredentialRequest;
 };
-export type ApiCredentialsPartialUpdateApiResponse =
-  /** status 200  */ Credential;
+export type ApiCredentialsPartialUpdateApiResponse = /** status 200  */ Credential;
 export type ApiCredentialsPartialUpdateApiArg = {
   /** A unique value identifying this credential. */
   id: string;
@@ -979,8 +976,7 @@ export type ApiCredentialsDestroyApiArg = {
   /** A unique value identifying this credential. */
   id: string;
 };
-export type ApiExploreCreateApiResponse =
-  /** status 200  */ ExplorationResponse;
+export type ApiExploreCreateApiResponse = /** status 200  */ ExplorationResponse;
 export type ApiExploreCreateApiArg = {
   explorationRequestRequest: ExplorationRequestRequest;
 };
@@ -1035,8 +1031,7 @@ export type ApiInputGroupsUpdateApiArg = {
   id: string;
   inputGroupRequest: InputGroupRequest;
 };
-export type ApiInputGroupsPartialUpdateApiResponse =
-  /** status 200  */ InputGroup;
+export type ApiInputGroupsPartialUpdateApiResponse = /** status 200  */ InputGroup;
 export type ApiInputGroupsPartialUpdateApiArg = {
   /** A unique value identifying this input group. */
   id: string;
@@ -1184,8 +1179,7 @@ export type ApiSourcesDestroyApiArg = {
   /** A unique value identifying this source. */
   id: string;
 };
-export type ApiSourcesExportRetrieveApiResponse =
-  /** status 200  */ MappingWithPartialCredential;
+export type ApiSourcesExportRetrieveApiResponse = /** status 200  */ MappingWithPartialCredential;
 export type ApiSourcesExportRetrieveApiArg = {
   /** A unique value identifying this source. */
   id: string;
@@ -1247,8 +1241,7 @@ export type ApiStaticInputsUpdateApiArg = {
   id: string;
   staticInputRequest: StaticInputRequest;
 };
-export type ApiStaticInputsPartialUpdateApiResponse =
-  /** status 200  */ StaticInput;
+export type ApiStaticInputsPartialUpdateApiResponse = /** status 200  */ StaticInput;
 export type ApiStaticInputsPartialUpdateApiArg = {
   /** A unique value identifying this static input. */
   id: string;
@@ -1341,14 +1334,14 @@ export type Condition = {
   id: string;
   action: ActionEnum;
   value?: string;
-  relation?: ConditionRelationEnum;
+  relation: ConditionRelationEnum;
   sql_input: string;
   input_group: string;
 };
 export type ConditionRequest = {
   action: ActionEnum;
   value?: string;
-  relation?: ConditionRelationEnum;
+  relation: ConditionRelationEnum;
   sql_input: string;
   input_group: string;
 };

--- a/django/pyrog/api/serializers/basic.py
+++ b/django/pyrog/api/serializers/basic.py
@@ -160,6 +160,7 @@ class ConditionSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Condition
         fields = "__all__"
+        extra_kwargs = {"relation": {"required": True}}
 
 
 class FilterSerializer(serializers.ModelSerializer):

--- a/river-schema.yml
+++ b/river-schema.yml
@@ -2618,6 +2618,7 @@ components:
       - action
       - id
       - input_group
+      - relation
       - sql_input
     ConditionRelationEnum:
       enum:
@@ -2645,6 +2646,7 @@ components:
       required:
       - action
       - input_group
+      - relation
       - sql_input
     Credential:
       type: object


### PR DESCRIPTION
## Fixes

- Fixes #642 

## Technical details

- Instead of making `relation` not required for a `condition` creation, we changed the `ConditionSerializer` to make `relation` required in POST requests.

## Definition of Done

- [x] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [x] I have written tests for the code I added or updated.
- [x] I have updated the documentation according to my changes.
- [x] I have updated the deployment configuration if needed.
