### PR TITLE
Fix requests performance optimisations

### DIFF
--- a/app/src/common/hooks/useIsNodePending.tsx
+++ b/app/src/common/hooks/useIsNodePending.tsx
@@ -48,18 +48,18 @@ const useIsNodePending = (node: ElementNode): boolean => {
     { skip: !mappingId }
   );
   const { data: inputGroups } = useApiInputGroupsListQuery(
-    {},
+    { resource: mappingId },
     {
-      skip: !attributes,
+      skip: !mappingId,
     }
   );
   const { data: sqlInputs } = useApiSqlInputsListQuery(
-    {},
-    { skip: !inputGroups }
+    { resource: mappingId },
+    { skip: !mappingId }
   );
   const { data: staticInputs } = useApiStaticInputsListQuery(
-    {},
-    { skip: !inputGroups }
+    { resource: mappingId },
+    { skip: !mappingId }
   );
 
   const inputs: (SqlInput | StaticInput)[] | undefined = useMemo(() => {

--- a/app/src/services/api/generated/api.generated.ts
+++ b/app/src/services/api/generated/api.generated.ts
@@ -375,7 +375,11 @@ export const api = createApi({
     >({
       query: (queryArg) => ({
         url: `/api/input-groups/`,
-        params: { attribute: queryArg.attribute, ordering: queryArg.ordering },
+        params: {
+          attribute: queryArg.attribute,
+          ordering: queryArg.ordering,
+          resource: queryArg.resource,
+        },
       }),
     }),
     apiInputGroupsCreate: build.mutation<
@@ -689,6 +693,7 @@ export const api = createApi({
         params: {
           input_group: queryArg.inputGroup,
           ordering: queryArg.ordering,
+          resource: queryArg.resource,
         },
       }),
     }),
@@ -746,6 +751,7 @@ export const api = createApi({
         params: {
           input_group: queryArg.inputGroup,
           ordering: queryArg.ordering,
+          resource: queryArg.resource,
         },
       }),
     }),
@@ -1015,6 +1021,7 @@ export type ApiInputGroupsListApiArg = {
   attribute?: string;
   /** Which field to use when ordering the results. */
   ordering?: string;
+  resource?: string;
 };
 export type ApiInputGroupsCreateApiResponse = /** status 201  */ InputGroup;
 export type ApiInputGroupsCreateApiArg = {
@@ -1193,6 +1200,7 @@ export type ApiSqlInputsListApiArg = {
   inputGroup?: string;
   /** Which field to use when ordering the results. */
   ordering?: string;
+  resource?: string;
 };
 export type ApiSqlInputsCreateApiResponse = /** status 201  */ SqlInput;
 export type ApiSqlInputsCreateApiArg = {
@@ -1225,6 +1233,7 @@ export type ApiStaticInputsListApiArg = {
   inputGroup?: string;
   /** Which field to use when ordering the results. */
   ordering?: string;
+  resource?: string;
 };
 export type ApiStaticInputsCreateApiResponse = /** status 201  */ StaticInput;
 export type ApiStaticInputsCreateApiArg = {

--- a/django/pyrog/api/filters.py
+++ b/django/pyrog/api/filters.py
@@ -47,18 +47,24 @@ class AttributeFilterSet(filters.FilterSet):
 
 
 class InputGroupFilterSet(filters.FilterSet):
+    resource = filters.ModelChoiceFilter("attribute__resource", queryset=models.Resource.objects.all())
+
     class Meta:
         model = models.InputGroup
         fields = ["attribute"]
 
 
 class StaticInputFilterSet(filters.FilterSet):
+    resource = filters.ModelChoiceFilter("input_group__attribute__resource", queryset=models.Resource.objects.all())
+
     class Meta:
         model = models.StaticInput
         fields = ["input_group"]
 
 
 class SQLInputFilterSet(filters.FilterSet):
+    resource = filters.ModelChoiceFilter("input_group__attribute__resource", queryset=models.Resource.objects.all())
+
     class Meta:
         model = models.SQLInput
         fields = ["input_group"]

--- a/river-schema.yml
+++ b/river-schema.yml
@@ -1143,6 +1143,10 @@ paths:
         description: Which field to use when ordering the results.
         schema:
           type: string
+      - in: query
+        name: resource
+        schema:
+          type: string
       tags:
       - api
       security:
@@ -2116,6 +2120,10 @@ paths:
         description: Which field to use when ordering the results.
         schema:
           type: string
+      - in: query
+        name: resource
+        schema:
+          type: string
       tags:
       - api
       security:
@@ -2284,6 +2292,10 @@ paths:
         required: false
         in: query
         description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: resource
         schema:
           type: string
       tags:

--- a/tests/pyrog/api/test_input_group.py
+++ b/tests/pyrog/api/test_input_group.py
@@ -85,3 +85,22 @@ def test_filter_input_groups_by_attribute(api_client, attribute_factory, input_g
     assert {input_group_data["id"] for input_group_data in response.json()} == {
         input_group.id for input_group in first_attribute_input_groups
     }
+
+
+def test_filter_input_groups_by_resource(api_client, resource_factory, attribute_factory, input_group_factory):
+    url = reverse("input-groups-list")
+
+    first_resource = resource_factory.create()
+    first_resource_attribute = attribute_factory.create(resource=first_resource)
+    first_attribute_input_groups = input_group_factory.create_batch(2, attribute=first_resource_attribute)
+
+    second_resource = resource_factory.create()
+    second_resource_attribute = attribute_factory.create(resource=second_resource)
+    input_group_factory.create_batch(3, attribute=second_resource_attribute)
+
+    response = api_client.get(url, {"resource": first_resource.id})
+
+    assert response.status_code == 200, response.data
+    assert {input_group_data["id"] for input_group_data in response.json()} == {
+        input_group.id for input_group in first_attribute_input_groups
+    }

--- a/tests/pyrog/api/test_sql_input.py
+++ b/tests/pyrog/api/test_sql_input.py
@@ -80,3 +80,24 @@ def test_filter_sql_inputs_by_input_group(api_client, input_group_factory, sql_i
 
     assert response.status_code == 200, response.data
     assert {input_data["id"] for input_data in response.json()} == {input.id for input in first_input_group_inputs}
+
+
+def test_filter_sql_inputs_by_resource(
+    api_client, input_group_factory, attribute_factory, resource_factory, sql_input_factory
+):
+    url = reverse("sql-inputs-list")
+
+    first_resource = resource_factory()
+    first_resource_attribute = attribute_factory.create(resource=first_resource)
+    first_attribute_input_group = input_group_factory.create(attribute=first_resource_attribute)
+    first_input_group_inputs = sql_input_factory.create_batch(3, input_group=first_attribute_input_group)
+
+    second_resource = resource_factory()
+    second_resource_attribute = attribute_factory.create(resource=second_resource)
+    second_attribute_input_group = input_group_factory.create(attribute=second_resource_attribute)
+    sql_input_factory.create_batch(4, input_group=second_attribute_input_group)
+
+    response = api_client.get(url, {"resource": first_resource.id})
+
+    assert response.status_code == 200, response.data
+    assert {input_data["id"] for input_data in response.json()} == {input.id for input in first_input_group_inputs}

--- a/tests/pyrog/api/test_static_input.py
+++ b/tests/pyrog/api/test_static_input.py
@@ -76,3 +76,24 @@ def test_filter_static_inputs_by_input_group(api_client, input_group_factory, st
 
     assert response.status_code == 200, response.data
     assert {input_data["id"] for input_data in response.json()} == {input.id for input in first_input_group_inputs}
+
+
+def test_filter_static_inputs_by_resource(
+    api_client, input_group_factory, attribute_factory, resource_factory, static_input_factory
+):
+    url = reverse("static-inputs-list")
+
+    first_resource = resource_factory()
+    first_resource_attribute = attribute_factory.create(resource=first_resource)
+    first_attribute_input_group = input_group_factory.create(attribute=first_resource_attribute)
+    first_input_group_inputs = static_input_factory.create_batch(3, input_group=first_attribute_input_group)
+
+    second_resource = resource_factory()
+    second_resource_attribute = attribute_factory.create(resource=second_resource)
+    second_attribute_input_group = input_group_factory.create(attribute=second_resource_attribute)
+    static_input_factory.create_batch(4, input_group=second_attribute_input_group)
+
+    response = api_client.get(url, {"resource": first_resource.id})
+
+    assert response.status_code == 200, response.data
+    assert {input_data["id"] for input_data in response.json()} == {input.id for input in first_input_group_inputs}


### PR DESCRIPTION
## Fixes

- Fixes #460 

## Description

- Added `resource` filters for `InputGoups`, `SqlInputs` & `StaticInputs` list queries. This should solve request calls that resulted with responses with item count > 5000.

## Definition of Done

- [x] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [x] I have written tests for the code I added or updated.
- [x] I have updated the documentation according to my changes.
- [x] I have updated the deployment configuration if needed.
